### PR TITLE
#6: Remove Access

### DIFF
--- a/web/db/actions/Account.ts
+++ b/web/db/actions/Account.ts
@@ -1,1 +1,8 @@
+import { ClientSession } from "mongoose";
 import Account from "../models/Account";
+
+async function removeAccount(email: string, session?: ClientSession) {
+  return await Account.findOneAndDelete({ email }, { session: session });
+}
+
+export { removeAccount };

--- a/web/db/actions/User.ts
+++ b/web/db/actions/User.ts
@@ -1,1 +1,12 @@
-import User from "../models/User";
+import { ClientSession, UpdateQuery } from "mongoose";
+import User, { IUser } from "../models/User";
+
+async function updateUser(
+  email: string,
+  update: UpdateQuery<IUser>,
+  session?: ClientSession
+) {
+  return await User.findOneAndUpdate({ email }, update, { session: session });
+}
+
+export { updateUser };

--- a/web/db/dbConnect.ts
+++ b/web/db/dbConnect.ts
@@ -16,7 +16,9 @@ async function dbConnect() {
 
   if (!cached.promise) {
     cached.promise = mongoose
-      .connect(consts.dbUrl as string)
+      .connect(consts.dbUrl as string, {
+        dbName: consts.dbName,
+      })
       .then((mongoose) => {
         return mongoose;
       });

--- a/web/server/routers/_app.ts
+++ b/web/server/routers/_app.ts
@@ -1,8 +1,10 @@
 import { router } from "../trpc";
 import { userRouter } from "./user";
 import { postRouter } from "./post";
+import { accountRouter } from "./account";
 
 export const appRouter = router({
+  account: accountRouter,
   user: userRouter,
   post: postRouter,
 });

--- a/web/server/routers/account.ts
+++ b/web/server/routers/account.ts
@@ -1,2 +1,42 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { removeAccount } from "../../db/actions/Account";
+import { updateUser } from "../../db/actions/User";
+import Account from "../../db/models/Account";
 import { router, protectedProcedure } from "../trpc";
-export const accountRouter = router({});
+
+export const accountRouter = router({
+  remove: protectedProcedure
+    .input(
+      z.object({
+        email: z.string().email("Invalid email provided"),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const email = input.email;
+      if (ctx.session?.email === email)
+        throw new TRPCError({
+          message: "Unauthorized - Cannot remove own account",
+          code: "UNAUTHORIZED",
+        });
+
+      const session = await Account.startSession();
+      session.startTransaction();
+
+      try {
+        await removeAccount(email, session);
+        await updateUser(email, { disabled: true }, session);
+
+        session.commitTransaction();
+
+        return { success: true };
+      } catch (e) {
+        session.abortTransaction();
+
+        throw new TRPCError({
+          message: "Internal Server Error",
+          code: "INTERNAL_SERVER_ERROR",
+        });
+      }
+    }),
+});

--- a/web/utils/consts.ts
+++ b/web/utils/consts.ts
@@ -1,5 +1,6 @@
 const consts = {
   dbUrl: process.env.DB_URL,
+  dbName: "angels-among-us",
 };
 
 export { consts };


### PR DESCRIPTION
## Remove Access

Issue Number(s): #6 .

This PR adds removal functionality for accounts. It adds this functionality by request from admins to have the ability to remove stale accounts (See #6 for full contextual info).

### Checklist

- [x ] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

None

### Related PRs

None

### Testing

To test correct functionality:

1. Create a set of accounts in the `account` collection. Additionally, create some users in the `user` collection.
2. Start the development server
3. Run the following curl command: `curl -X POST http://localhost:3000/api/trpc/account.remove -H "Content-Type: application/json" -d '{"email": "[email of account here]"}'`
4. Check the results in MongoDB compass.

To test error conditions:
1. Create some accounts as above
2. Add in `throw new Error()` at any point in the `try` block either before, in-between, or after the `remove` and `update` function calls. 
3. Check the results in MongoDB Compass: all data should remain the same (no deletion or updates)