### PR TITLE
#8: Modify Access

### DIFF
--- a/web/db/actions/Account.ts
+++ b/web/db/actions/Account.ts
@@ -1,8 +1,18 @@
-import { ClientSession } from "mongoose";
-import Account from "../models/Account";
+import { ClientSession, UpdateQuery } from "mongoose";
+import Account, { IAccount } from "../models/Account";
 
 async function removeAccount(email: string, session?: ClientSession) {
   return await Account.findOneAndDelete({ email }, { session: session });
 }
 
-export { removeAccount };
+async function updateAccount(
+  email: string,
+  update: UpdateQuery<IAccount>,
+  session?: ClientSession
+) {
+  return await Account.findOneAndUpdate({ email }, update, {
+    session: session,
+  });
+}
+
+export { removeAccount, updateAccount };

--- a/web/server/routers/account.ts
+++ b/web/server/routers/account.ts
@@ -1,17 +1,63 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { removeAccount } from "../../db/actions/Account";
+import { removeAccount, updateAccount } from "../../db/actions/Account";
 import { updateUser } from "../../db/actions/User";
 import Account from "../../db/models/Account";
 import { router, protectedProcedure } from "../trpc";
 
+const emailInput = {
+  email: z.string().email("Invalid email provided"),
+};
+
 export const accountRouter = router({
-  remove: protectedProcedure
+  modify: protectedProcedure
     .input(
       z.object({
-        email: z.string().email("Invalid email provided"),
+        admin: z.boolean(),
+        ...emailInput,
       })
     )
+    .mutation(async ({ ctx, input }) => {
+      const email = input.email;
+      if (ctx.session?.email === email)
+        throw new TRPCError({
+          message: "Unauthorized - Cannot modify own account",
+          code: "UNAUTHORIZED",
+        });
+
+      const session = await Account.startSession();
+      session.startTransaction();
+
+      try {
+        const updateResult = await updateAccount(
+          email,
+          { admin: input.admin },
+          session
+        );
+
+        if (!updateResult)
+          throw new TRPCError({
+            message: "Account with specified email not found",
+            code: "NOT_FOUND",
+          });
+
+        await updateUser(email, { admin: input.admin }, session);
+
+        session.commitTransaction();
+        return { success: true };
+      } catch (e) {
+        session.abortTransaction();
+
+        if (e instanceof TRPCError) throw e;
+        else
+          throw new TRPCError({
+            message: "Internal Server Error",
+            code: "INTERNAL_SERVER_ERROR",
+          });
+      }
+    }),
+  remove: protectedProcedure
+    .input(z.object(emailInput))
     .mutation(async ({ ctx, input }) => {
       const email = input.email;
       if (ctx.session?.email === email)


### PR DESCRIPTION
## Modify Access

Issue Number(s): #8 .

Allows admins to modify account access (admin -> standard and standard -> admin). Further context can be found on the issue (#8)

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

None

### Related PRs

None

### Testing

To test correct functionality:

1. Create a set of accounts in the account collection. Additionally, create some users in the user collection.
2. Start the development server
3. Run the following curl command: `curl -X POST http://localhost:3000/api/trpc/account.modify -H "Content-Type: application/json" -d '{"email": "[email of account here]"}'`
4. Check the results in MongoDB compass.

To test error conditions:

1. Create some accounts as above
2. Add in `throw new Error()` at any point in the try block either before, in-between, or after the remove and update function calls.
3. Call the above command again with the same payload (you should receive an error response)
4. Check the results in MongoDB Compass: all data should remain the same (no deletion or updates)
