### PR TITLE
Integrate File Uploads & Post Get Endpoint

### DIFF
--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -79,7 +79,7 @@ async function finalizePost(id: ObjectId, session?: ClientSession) {
     Prefix: `${id}`,
   });
   const attachmentKeys = post.attachments.sort();
-
+  if (post.attachments.length == 0) return;
   if (
     !uploadedObjects.Contents ||
     uploadedObjects.KeyCount !== attachmentKeys.length

--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -79,7 +79,7 @@ async function finalizePost(id: ObjectId, session?: ClientSession) {
     Prefix: `${id}`,
   });
   const attachmentKeys = post.attachments.sort();
-  if (post.attachments.length == 0) return;
+  if (post.attachments.length == 0) return post;
   if (
     !uploadedObjects.Contents ||
     uploadedObjects.KeyCount !== attachmentKeys.length

--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -9,6 +9,14 @@ import storageClient from "../storageConnect";
 
 type UploadInfo = Record<string, string>;
 
+async function getPost(oid: ObjectId) {
+  const post = await Post.findOne({ _id: oid });
+  post.attachments = post.attachments.map((attachment: string) => {
+    return `${consts.storageBucketURL}/${attachment}`;
+  });
+  return post;
+}
+
 async function createPost(post: IPendingPost, session?: ClientSession) {
   const pending = post.attachments.length != 0;
   const createdPost = await Post.create(
@@ -116,4 +124,10 @@ async function updatePostStatus(oid: ObjectId, session?: ClientSession) {
     { session: session }
   );
 }
-export { createPost, updatePostDetails, updatePostStatus, finalizePost };
+export {
+  createPost,
+  getPost,
+  updatePostDetails,
+  updatePostStatus,
+  finalizePost,
+};

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   createPost,
   finalizePost,
+  getPost,
   updatePostDetails,
   updatePostStatus,
 } from "../../db/actions/Post";
@@ -21,7 +22,7 @@ import {
   Trained,
   Status,
 } from "../../utils/types/post";
-import { router, creatorProcedure } from "../trpc";
+import { router, creatorProcedure, publicProcedure } from "../trpc";
 
 const zodOidType = z.custom<ObjectId>((item) => String(item).length == 24);
 
@@ -55,6 +56,15 @@ const postSchema = z.object({
 });
 
 export const postRouter = router({
+  get: publicProcedure
+    .input(
+      z.object({
+        _id: zodOidType,
+      })
+    )
+    .query(async ({ input }) => {
+      return getPost(input._id);
+    }),
   create: creatorProcedure.input(postSchema).mutation(async ({ input }) => {
     const session = await Post.startSession();
     session.startTransaction();

--- a/web/utils/consts.ts
+++ b/web/utils/consts.ts
@@ -27,6 +27,7 @@ const consts = {
   storageBucket: process.env.STORAGE_BUCKET_NAME,
   storageS3Endpoint: process.env.STORAGE_S3_ENDPOINT,
   storageS3Region: process.env.STORAGE_S3_REGION,
+  storageBucketURL: process.env.STORAGE_BUCKET_URL,
 };
 
 export { Pages, consts };


### PR DESCRIPTION
## Integrate File Uploads & Post Get Endpoint
Issue Number(s): #49.

This PR adds in the frontend code for file uploads based on the files selected from the Post Creation flow.

It also adds a backend endpoint to get a post (which rewrites the attachments into URLs)

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- env.STORAGE_BUCKET_URL must be set to the url of the bucket to use (either dev, staging, prod and the Cloudflare equivalent if we're putting this behind Cloudflare). If it's not behind Cloudflare this should be the Friendly URL that is seen when clicking info on any of the files in the R2 bucket.

- It should be `https://pub-27cb50e8f369479a8f312921bab07d36.r2.dev` for dev, `https://pub-60dbb602de0044eb8fe107bea1ba8e11.r2.dev` for staging, and `https://pub-9ce2c0f13dbd4306ba73805254cda8ca.r2.dev` for production

### Testing

For Uploading:

Log into the webpage and test the post creation. Open the console and view the returned log info. Additionally, check mongodb for the object ID in the logs and ensure `pending` is false and `attachments` is populated with each file chosen to upload.

For the GET endpoint:

Encode the JSON payload {"_id":"[objectid]"} using some URL encoder and in your browser (after logging in) type in the URL `http://localhost:3000/api/trpc/post.get?input=[encodedString]` and the info should pop up