### PR TITLE
#80: Add a filter API route for Users

### DIFF
--- a/web/db/actions/User.ts
+++ b/web/db/actions/User.ts
@@ -1,11 +1,13 @@
 import {
   ClientSession,
+  FilterQuery,
   HydratedDocument,
   ObjectId,
   UpdateQuery,
 } from "mongoose";
 import User from "../models/User";
 import { IUser } from "../../utils/types/user";
+import { Role } from "../../utils/types/account";
 
 async function createUser(user: IUser, session?: ClientSession) {
   return await User.create([user], { session: session });
@@ -44,9 +46,37 @@ async function updateUserByUid(
   return await User.findOneAndUpdate({ uid }, update, { session: session });
 }
 
+async function filterUsers(roles: Role[], emailQuery: string) {
+  return await User.aggregate([
+    {
+      $search: {
+        compound: {
+          must: [
+            {
+              text: {
+                query: roles,
+                path: "role",
+              },
+            },
+          ],
+          filter: [
+            {
+              text: {
+                query: emailQuery,
+                path: "email",
+              },
+            },
+          ],
+        },
+      },
+    },
+  ]);
+}
+
 export {
   createUser,
   findUserByUid,
+  filterUsers,
   updateAllUsers,
   updateUserByEmail,
   updateUserByUid,

--- a/web/db/actions/User.ts
+++ b/web/db/actions/User.ts
@@ -47,27 +47,34 @@ async function updateUserByUid(
 }
 
 async function filterUsers(roles: Role[], emailQuery: string) {
+  const role = {
+    must: [
+      {
+        text: {
+          query: roles,
+          path: "role",
+        },
+      },
+    ],
+  };
+
+  const email = {
+    filter: [
+      {
+        text: {
+          query: emailQuery,
+          path: "email",
+        },
+      },
+    ],
+  };
+
+  const compound = emailQuery.length != 0 ? { ...role, ...email } : { ...role };
+
   return await User.aggregate([
     {
       $search: {
-        compound: {
-          must: [
-            {
-              text: {
-                query: roles,
-                path: "role",
-              },
-            },
-          ],
-          filter: [
-            {
-              text: {
-                query: emailQuery,
-                path: "email",
-              },
-            },
-          ],
-        },
+        compound,
       },
     },
   ]);

--- a/web/server/routers/user.ts
+++ b/web/server/routers/user.ts
@@ -1,7 +1,8 @@
-import { router, publicProcedure } from "../trpc";
-import { boolean, z } from "zod";
+import { router, publicProcedure, protectedProcedure } from "../trpc";
+import { z } from "zod";
 import {
   createUser,
+  filterUsers,
   findUserByUid,
   updateUserByUid,
 } from "../../db/actions/User";
@@ -139,5 +140,15 @@ export const userRouter = router({
           code: "INTERNAL_SERVER_ERROR",
         });
       }
+    }),
+  filter: protectedProcedure
+    .input(
+      z.object({
+        roles: z.array(z.nativeEnum(Role)),
+        query: z.string(),
+      })
+    )
+    .query(async ({ input }) => {
+      return filterUsers(input.roles, input.query);
     }),
 });

--- a/web/server/routers/user.ts
+++ b/web/server/routers/user.ts
@@ -144,11 +144,14 @@ export const userRouter = router({
   filter: protectedProcedure
     .input(
       z.object({
-        roles: z.array(z.nativeEnum(Role)),
-        query: z.string(),
+        roles: z
+          .array(z.nativeEnum(Role))
+          .optional()
+          .default(Object.values(Role)),
+        query: z.string().optional().default(""),
       })
     )
-    .query(async ({ input }) => {
+    .mutation(async ({ input }) => {
       return filterUsers(input.roles, input.query);
     }),
 });


### PR DESCRIPTION
## Add User filter API Route

Issue Number(s): #80 .

Adds a route: `user.filter` to get a list of users based on the given list of allowed roles and email query string

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

The atlas database needs to have an Atlas Search index added to it. The index name should be left as default. The configuration should be set to the one below.

The JSON configuration for the index is here:

```json
{
  "analyzer": "emailAutocomplete",
  "mappings": {
    "dynamic": false,
    "fields": {
      "email": {
        "analyzer": "emailAutocomplete",
        "type": "string"
      },
      "role": {
        "analyzer": "lucene.standard",
        "type": "string"
      }
    }
  },
  "analyzers": [
    {
      "charFilters": [],
      "name": "emailAutocomplete",
      "tokenFilters": [
        {
          "maxGram": 4,
          "minGram": 1,
          "type": "nGram"
        }
      ],
      "tokenizer": {
        "type": "keyword"
      }
    }
  ]
}
```
### Testing

Setup an Atlas instance and perform the queries with URL-encoded JSON payloads. This must be tested on an Atlas instance as local MongoDB does not support Atlas Search queries
