### PR TITLE
Fix post document db schema

### DIFF
--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -18,7 +18,6 @@ async function getPost(oid: ObjectId) {
 }
 
 async function createPost(post: IPendingPost, session?: ClientSession) {
-  console.log(post);
   const pending = post.attachments.length != 0;
   const createdPost = await Post.create(
     [

--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -18,6 +18,7 @@ async function getPost(oid: ObjectId) {
 }
 
 async function createPost(post: IPendingPost, session?: ClientSession) {
+  console.log(post);
   const pending = post.attachments.length != 0;
   const createdPost = await Post.create(
     [
@@ -130,7 +131,14 @@ async function getAllPosts() {
 }
 
 async function getFilteredPosts(filter: FilterQuery<IPost>) {
-  return await Post.find(filter).sort({ date: -1 });
+  const posts = await Post.find(filter).sort({ date: -1 });
+  posts.forEach(
+    (post) =>
+      (post.attachments = post.attachments.map(
+        (attachment: string) => `${consts.storageBucketURL}/${attachment}`
+      ))
+  );
+  return posts;
 }
 
 export {

--- a/web/db/models/Post.ts
+++ b/web/db/models/Post.ts
@@ -12,11 +12,19 @@ import {
   Behavioral,
   Trained,
   Status,
+  PetKind,
 } from "../../utils/types/post";
 const { Schema } = mongoose;
 
 const postSchema = new Schema<IPost>({
   date: { type: Date, default: Date.now },
+  name: { type: String, required: true },
+  description: { type: String, required: true },
+  petKind: {
+    type: String,
+    required: true,
+    enum: Object.values(PetKind),
+  },
   type: {
     type: String,
     required: true,

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -23,12 +23,16 @@ import {
   Behavioral,
   Trained,
   Status,
+  PetKind,
 } from "../../utils/types/post";
 import { router, procedure } from "../trpc";
 
 const zodOidType = z.custom<ObjectId>((item) => String(item).length == 24);
 
 const postSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  petKind: z.nativeEnum(PetKind),
   type: z.nativeEnum(FosterType),
   size: z.nativeEnum(Size),
   breed: z.array(z.nativeEnum(Breed)),

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -280,6 +280,9 @@ export type AttachmentInfo =
 
 export interface IPost {
   date: Date;
+  name: string;
+  description: string;
+  petKind: PetKind;
   type: FosterType;
   size: Size;
   breed: Breed[];


### PR DESCRIPTION
Fixes persistence of data when creating a post. All fields from the post creation form are now saved (`name`, `description`, `petKind` were missing before). Updates `getFilteredPosts` db action to add storage bucket URL onto each attachment.