### PR TITLE
#94 Populate Post Content

### DIFF
--- a/web/components/Feed/Feed.tsx
+++ b/web/components/Feed/Feed.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Dispatch, SetStateAction, useReducer } from "react";
+import { Dispatch, SetStateAction, useEffect, useReducer, useState } from "react";
 import { PossibleTypes } from "../../pages/onboarding";
 import {
   Age,
@@ -15,6 +15,7 @@ import {
   FosterType,
   Gender,
   GoodWith,
+  IPost,
   Size,
   Status,
   Temperament,
@@ -26,6 +27,7 @@ import FeedPostCard from "./FeedPostCard";
 import { AddIcon } from "@chakra-ui/icons";
 import { useAuth } from "../../context/auth";
 import { Role } from "../../utils/types/account";
+import { trpc } from "../../utils/trpc";
 
 export type FilterGroup = {
   title: string;
@@ -311,6 +313,11 @@ function Feed(props: {
     getInitialFilters()
   );
 
+  const allPosts = trpc.post.getAllPosts.useQuery().data;
+
+  const decoyPost = {} as IPost;
+  const [currentPostModalData, setCurrentPostModalData] = useState(decoyPost)
+
   const mainContent = (
     <Flex
       className="feed"
@@ -421,32 +428,27 @@ function Feed(props: {
             )}
           </Flex>
           <Stack spacing={5}>
-            <Box onClick={onPostViewOpen} _hover={{ cursor: "pointer" }}>
-              <FeedPostCard
-                image={
-                  "https://images.unsplash.com/photo-1615751072497-5f5169febe17?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8Mnx8Y3V0ZSUyMGRvZ3xlbnwwfHwwfHw%3D&w=1000&q=80"
-                }
-                date={"MM/DD/YYYY XX:XX PM"}
-                title={"Pet Name"}
-                tags={["Foster Move"]}
-                body={
-                  "Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur."
-                }
-              />
-            </Box>
-            <Box onClick={onPostViewOpen} _hover={{ cursor: "pointer" }}>
-              <FeedPostCard
-                image={
-                  "https://images.unsplash.com/photo-1615751072497-5f5169febe17?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8Mnx8Y3V0ZSUyMGRvZ3xlbnwwfHwwfHw%3D&w=1000&q=80"
-                }
-                date={"MM/DD/YYYY XX:XX PM"}
-                title={"Pet Name"}
-                tags={["Foster Move"]}
-                body={
-                  "Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur."
-                }
-              />
-            </Box>
+            {allPosts?.map((post: IPost) => {
+              return (
+                <Box
+                  onClick={() => {
+                    setCurrentPostModalData(post);
+                    onPostViewOpen();
+                  }}
+                  _hover={{ cursor: "pointer" }}
+                >
+                  <FeedPostCard
+                    image={post.attachments[0]}
+                    date={post.date.toString()}
+                    title={"Pet Name"}
+                    tags={post.temperament}
+                    body={
+                      "Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur."
+                    }
+                  />
+                </Box>
+              );
+            })}
           </Stack>
         </Flex>
       </Stack>
@@ -540,7 +542,11 @@ function Feed(props: {
         isOpen={isPostCreationOpen}
         onClose={onPostCreationClose}
       />
-      <PetPostModal isOpen={isPostViewOpen} onClose={onPostViewClose} />
+      <PetPostModal
+        isOpen={isPostViewOpen}
+        onClose={onPostViewClose}
+        postData={currentPostModalData}
+      />
     </>
   );
 }

--- a/web/components/Feed/Feed.tsx
+++ b/web/components/Feed/Feed.tsx
@@ -313,11 +313,6 @@ function Feed(props: {
     getInitialFilters()
   );
 
-  const allPosts = trpc.post.getAllPosts.useQuery().data;
-
-  const decoyPost = {} as IPost;
-  const [currentPostModalData, setCurrentPostModalData] = useState(decoyPost)
-
   const mainContent = (
     <Flex
       className="feed"

--- a/web/components/PetPostModal/PetPostListGroup.tsx
+++ b/web/components/PetPostModal/PetPostListGroup.tsx
@@ -1,0 +1,31 @@
+import {
+    Stack,
+    Tag,
+    TagLabel,
+    TagLeftIcon,
+    Text,
+    UnorderedList,
+    ListItem,
+    Wrap,
+    WrapItem,
+  } from "@chakra-ui/react";
+  export default function PetPostListGroup(props: {
+    title: string;
+    tags: Array<String>;
+  }) {
+    return (
+      <Stack direction="column" spacing={3}>
+        <Text fontWeight="bold" fontSize="xl" fontFamily="sans-serif">
+          {props.title}
+        </Text>
+        <UnorderedList>
+          {props.tags.map((tag) => {
+            return (
+              <ListItem>{tag}</ListItem>
+            );
+          })}
+        </UnorderedList>
+      </Stack>
+    );
+  }
+  

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -3,18 +3,55 @@ import "react-responsive-carousel/lib/styles/carousel.min.css";
 import {
   Button,
   Flex,
+  ListItem,
   Modal,
   ModalContent,
   Stack,
   Text,
+  UnorderedList,
 } from "@chakra-ui/react";
 import ImageSlider from "./ImageSlider";
 import PetPostTagGroup from "./PetPostTagGroup";
+import PetPostListGroup from "./PetPostListGroup";
+import {
+  breedLabels,
+  genderLabels,
+  sizeLabels,
+  ageLabels,
+  IPost,
+  behavioralLabels,
+  medicalLabels,
+  spayNeuterStatusLabels,
+  houseTrainedLabels,
+  crateTrainedLabels,
+  GoodWith,
+  Trained,
+  goodWithLabels,
+} from "../../utils/types/post";
 
 const PetPostModal: React.FC<{
   isOpen: boolean;
   onClose: () => void;
-}> = ({ isOpen, onClose }) => {
+  postData: IPost;
+}> = ({ isOpen, onClose, postData }) => {
+  const behavioralTagLabels: String[] = [];
+  postData.behavioral?.map((tag) => {
+    behavioralTagLabels.push(behavioralLabels[tag]);
+  });
+
+  const medicalTagLabels: String[] = [
+    spayNeuterStatusLabels[postData.spayNeuterStatus],
+    houseTrainedLabels[postData.houseTrained],
+    crateTrainedLabels[postData.crateTrained],
+  ];
+
+  postData.medical?.map((tag) => {
+    medicalTagLabels.push(medicalLabels[tag]);
+  });
+
+  const behavioralAndMedicalTagLabels =
+    medicalTagLabels.concat(behavioralTagLabels);
+
   return (
     <Modal isOpen={isOpen} size={"full"} onClose={onClose}>
       <ModalContent>
@@ -60,59 +97,63 @@ const PetPostModal: React.FC<{
                   Lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit
                   amet consectetur.
                 </Text>
-                <Text>
-                  {
-                    "I am a foster move dog. My previous foster parents weren't able to care for me anymore."
-                  }
-                </Text>
+                <Text>{`${postData.type}`}</Text>
               </Stack>
               <Stack direction="column" spacing={8}>
                 <Flex direction="row" width="100%">
                   <Flex width="50%">
-                    <PetPostTagGroup
-                      title={"Main Characteristics"}
-                      tags={[
-                        "Male",
-                        "Australian Shepherd",
-                        "Medium-sized",
-                        "Adult",
-                      ]}
-                      icons={[CheckIcon, CheckIcon, CheckIcon, CheckIcon]}
-                    />
+                    <Stack direction="column" spacing={3}>
+                      <Text
+                        fontWeight="bold"
+                        fontSize="xl"
+                        fontFamily="sans-serif"
+                      >
+                        {"Main Characteristics"}
+                      </Text>
+                      <UnorderedList>
+                        <ListItem>
+                          <Text>Gender: {genderLabels[postData.gender]}</Text>
+                        </ListItem>
+                        <ListItem>
+                          <Text>
+                            Breed:{" "}
+                            {postData.breed?.map((breed) => {
+                              return `${breedLabels[breed]}${
+                                postData.breed.indexOf(breed) ===
+                                postData.breed.length - 1
+                                  ? " "
+                                  : ", "
+                              }`;
+                            })}
+                          </Text>
+                        </ListItem>
+                        <ListItem>
+                          <Text>Size: {sizeLabels[postData.size]}</Text>
+                        </ListItem>
+                        <ListItem>
+                          <Text>Age: {ageLabels[postData.age]}</Text>
+                        </ListItem>
+                      </UnorderedList>
+                    </Stack>
                   </Flex>
                   <Flex width="50%">
-                    <PetPostTagGroup
+                    <PetPostListGroup
                       title={"Behavioral and Medical Info"}
-                      tags={[
-                        "House-trained",
-                        "Friendly",
-                        "Heartworms",
-                        "Flight Risk",
-                        "Spayed/Neutered",
-                      ]}
-                      icons={[
-                        CheckIcon,
-                        CheckIcon,
-                        CheckIcon,
-                        CheckIcon,
-                        CheckIcon,
-                      ]}
+                      tags={behavioralAndMedicalTagLabels}
                     />
                   </Flex>
                 </Flex>
                 <Flex direction="row" width="100%">
                   <Flex width="50%">
-                    <PetPostTagGroup
+                    <PetPostListGroup
                       title={"I'm not comfortable with"}
-                      tags={["Cats", "Young Children"]}
-                      icons={[CheckIcon, CheckIcon]}
+                      tags={[]}
                     />
                   </Flex>
                   <Flex width="50%">
-                    <PetPostTagGroup
+                    <PetPostListGroup
                       title={"I'm comfortable with"}
-                      tags={["Cats", "Young Children"]}
-                      icons={[CheckIcon, CheckIcon]}
+                      tags={[]}
                     />
                   </Flex>
                 </Flex>

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -264,6 +264,24 @@ export const trainedLabels: Record<Trained, string> = {
   [Trained.Unknown]: "Unknown",
 };
 
+export const houseTrainedLabels: Record<Trained, string> = {
+    [Trained.Yes]: "House-Trained",
+    [Trained.No]: "Not House-Trained",
+    [Trained.Unknown]: "House-Training Status Unknown",
+}
+
+export const crateTrainedLabels: Record<Trained, string> = {
+    [Trained.Yes]: "Crate-Trained",
+    [Trained.No]: "Not Crate-Trained",
+    [Trained.Unknown]: "Crate-Training Status Unknown",
+}
+
+export const spayNeuterStatusLabels: Record<Trained, string> = {
+    [Trained.Yes]: "Spayed/Neutered",
+    [Trained.No]: "Not Spayed/Neutered",
+    [Trained.Unknown]: "Spay/Neuter Status Not Known",
+}
+
 export enum Status {
   Yes = "yes",
   No = "no",


### PR DESCRIPTION
## Populate Post Content

Issue Number(s): #94 

What does this PR change and why?

Add post persistence with database
- One API call is made to fetch posts to the feed
- Post data is passed into Post Modal as props when user clicks on a post
- Post data populates the feed and modal to match the database

Update post modal styling to match new designs
- Change tag style from bubbles to bulleted lists
- Fix foster me button position

### Checklist

- [ ] Requirements have been implemented
- [ ] Acceptance criteria are met
- [ ] Database schema docs have been updated or are not necessary
- [ ] Code follows design and style guidelines
- [ ] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

None

### Related PRs

- #number_of_pr

### Testing

- On page load, feed should populate with all posts from the database
- Clicking on a post should open post modal and display data for that post as expected
- If post information exceeds shown amount, foster me button is fixed to bottom of modal
