### PR TITLE
Mark post as covered

### DIFF
--- a/web/components/Feed/Feed.tsx
+++ b/web/components/Feed/Feed.tsx
@@ -514,7 +514,7 @@ function Feed(props: {
               </Button>
             )}
           </Flex>
-          <Stack overflowY="auto">
+          <Stack overflowY="auto" spacing={0}>
             {feedPosts?.map((p, ind) => {
               return (
                 <Box

--- a/web/components/Feed/Feed.tsx
+++ b/web/components/Feed/Feed.tsx
@@ -2,7 +2,9 @@ import { AddIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
+  Center,
   Flex,
+  Spinner,
   Stack,
   Text,
   useDisclosure,
@@ -29,6 +31,7 @@ import FeedFilterGroup from "./FeedFilterGroup";
 import FeedPostCard from "./FeedPostCard";
 import { Types } from "mongoose";
 import Select from "react-select";
+import useDebounce from "../../hooks/useDebounce";
 
 export type FilterGroup = {
   title: string;
@@ -377,6 +380,7 @@ function Feed(props: {
       postFilters: getQueryFilters(selectedFilters),
       covered: role === Role.Volunteer ? false : displayCovered,
     }).data;
+  const [debouncedFeedPosts, isUpdating] = useDebounce(feedPosts, 400);
 
   const [modalPostIndex, setModalPostIndex] = useState(0);
 
@@ -551,22 +555,28 @@ function Feed(props: {
               </Button>
             )}
           </Flex>
-          <Stack overflowY="auto" spacing={0}>
-            {feedPosts?.map((p, ind) => {
-              return (
-                <Box
-                  onClick={() => {
-                    setModalPostIndex(ind);
-                    onPostViewOpen();
-                  }}
-                  _hover={{ cursor: "pointer" }}
-                  key={ind}
-                >
-                  <FeedPostCard post={p} />
-                </Box>
-              );
-            })}
-          </Stack>
+          {isUpdating ? (
+            <Center height="75%" width="100%">
+              <Spinner size="xl" />
+            </Center>
+          ) : (
+            <Stack overflowY="auto" spacing={0}>
+              {debouncedFeedPosts?.map((p, ind) => {
+                return (
+                  <Box
+                    onClick={() => {
+                      setModalPostIndex(ind);
+                      onPostViewOpen();
+                    }}
+                    _hover={{ cursor: "pointer" }}
+                    key={ind}
+                  >
+                    <FeedPostCard post={p} />
+                  </Box>
+                );
+              })}
+            </Stack>
+          )}
         </Flex>
       </Stack>
     </Flex>
@@ -670,11 +680,11 @@ function Feed(props: {
         isOpen={isPostCreationOpen}
         onClose={onPostCreationClose}
       />
-      {feedPosts && feedPosts.length > 0 && (
+      {debouncedFeedPosts && debouncedFeedPosts.length > 0 && (
         <PetPostModal
           isOpen={isPostViewOpen}
           onClose={onPostViewClose}
-          postData={feedPosts[modalPostIndex]}
+          postData={debouncedFeedPosts[modalPostIndex]}
         />
       )}
     </>

--- a/web/components/Feed/FeedCoveredDropdown.tsx
+++ b/web/components/Feed/FeedCoveredDropdown.tsx
@@ -1,0 +1,68 @@
+import { Dispatch, SetStateAction } from "react";
+import Select from "react-select";
+
+const showingMap: Map<boolean | undefined, string> = new Map([
+  [undefined, "all posts"],
+  [true, "only covered posts"],
+  [false, "only uncovered posts"],
+]);
+
+const allDropdownOptions = Array.from(showingMap.entries()).map(([k, v]) => ({
+  value: k,
+  label: v,
+}));
+
+function FeedCoveredDropdown(props: {
+  displayCovered: boolean | undefined;
+  setDisplayCovered: Dispatch<SetStateAction<boolean | undefined>>;
+}) {
+  const { displayCovered, setDisplayCovered } = props;
+
+  const placeholder = `Showing ${showingMap.get(displayCovered)}`;
+
+  return (
+    <Select
+      controlShouldRenderValue={false}
+      placeholder={placeholder}
+      isSearchable={false}
+      isClearable={false}
+      menuPortalTarget={document.body}
+      styles={{
+        menu: (provided) => ({
+          ...provided,
+          zIndex: 9999,
+        }),
+        menuPortal: (provided) => ({
+          ...provided,
+          zIndex: 9999,
+        }),
+        control: (baseStyles) => ({
+          ...baseStyles,
+          minWidth: 200,
+          border: "1px solid #D9D9D9",
+          boxShadow: "none",
+          "&:hover": { border: "1px solid gray" },
+          borderRadius: "10px",
+          padding: 0,
+        }),
+        option: (provided, state) => ({
+          ...provided,
+          backgroundColor: state.isSelected ? "#57a0d5" : "white",
+          fontSize: "14px",
+        }),
+        placeholder: (baseStyles) => ({
+          ...baseStyles,
+          fontSize: "14px",
+        }),
+      }}
+      options={allDropdownOptions.filter(
+        (option) => option.value !== displayCovered
+      )}
+      onChange={(event) => {
+        setDisplayCovered(event!.value);
+      }}
+    />
+  );
+}
+
+export default FeedCoveredDropdown;

--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -114,7 +114,6 @@ function FeedPostCard(props: { post: IPost }) {
         position="absolute"
         width={{ lg: "52vw" }}
         height={"100%"}
-        zIndex={2}
         top={0}
         right={0}
         opacity={post.covered ? "30%" : "0%"}

--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -2,6 +2,8 @@ import { Card, Center, Flex, Image, Text } from "@chakra-ui/react";
 import DefaultDog from "../../public/dog.svg";
 import dayjs from "dayjs";
 import { fosterTypeLabels, IPost } from "../../utils/types/post";
+import { useAuth } from "../../context/auth";
+import { Role } from "../../utils/types/account";
 
 function DefaultDogImage() {
   return (
@@ -30,8 +32,11 @@ function DefaultDogImage() {
 //   description: string;
 // };
 
-function FeedPostCard(props: { post: IPost }) {
-  const { post } = props;
+function FeedPostCard(props: { post: IPost; hideCovered: boolean }) {
+  const { post, hideCovered } = props;
+
+  const { userData } = useAuth();
+  const role = userData?.role;
 
   let firstImage;
   const imageExtensions = new Set<string>(["png", "jpeg", "jpg"]);
@@ -50,57 +55,88 @@ function FeedPostCard(props: { post: IPost }) {
     .toString();
 
   return (
-    <Card
-      marginBottom="0px"
-      paddingX={{ base: "12px", lg: "16px" }}
-      paddingY={{ base: "16px", lg: "20px" }}
-      borderRadius="14px"
-      width={{ lg: "52vw" }}
+    <Flex
+      position="relative"
+      display={
+        ((role === Role.Admin || role === Role.ContentCreator) &&
+          (!post.covered || !hideCovered)) ||
+        (role === Role.Volunteer && !post.covered)
+          ? "flex"
+          : "none"
+      }
+      marginBottom="10px"
     >
-      <Flex gap={{ base: "15px", lg: "20px" }}>
-        {firstImage ? (
-          <Image
-            src={firstImage}
-            objectFit="cover"
-            minWidth={{ base: "120px", lg: "150px" }}
-            width={{ base: "120px", lg: "150px" }}
-            height={{ base: "120px", lg: "150px" }}
-            backgroundColor="#D9D9D9"
-            borderRadius="14px"
-          ></Image>
-        ) : (
-          <DefaultDogImage />
-        )}
-        <Flex
-          direction="column"
-          width="80%"
-          marginTop={{ base: "0px", lg: "8px" }}
-          marginRight="20px"
-        >
-          <Text fontSize="14px">{formattedDate}</Text>
-          <Text margin="0px" paddingY="0px" fontWeight="bold" fontSize="18px">
-            {post.name}
-          </Text>
-          <Text
-            margin="0px"
-            backgroundColor="#C6E3F9"
-            width="fit-content"
-            paddingX="16px"
-            paddingY="4px"
-            borderRadius="20px"
-            marginTop="5px"
-            marginBottom="10px"
-            fontSize="14px"
-            fontWeight="semibold"
-          >
-            {fosterTypeLabels[post.type]}
-          </Text>
-          <Text fontSize="14px" lineHeight="18px" color="#656565">
-            {post.description}
-          </Text>
+      <Card
+        paddingX={{ base: "12px", lg: "16px" }}
+        paddingY={{ base: "16px", lg: "20px" }}
+        borderRadius="14px"
+        borderStyle={"solid"}
+        borderColor={"#7d7e82a5"}
+        borderWidth={0.1}
+        width={{ lg: "52vw" }}
+      >
+        <Flex gap={{ base: "15px", lg: "20px" }}>
+          {firstImage ? (
+            <Image
+              src={firstImage}
+              objectFit="cover"
+              minWidth={{ base: "120px", lg: "150px" }}
+              width={{ base: "120px", lg: "150px" }}
+              height={{ base: "120px", lg: "150px" }}
+              backgroundColor="#D9D9D9"
+              borderRadius="14px"
+            ></Image>
+          ) : (
+            <DefaultDogImage />
+          )}
+          <Flex direction="column" width="80%" marginRight="20px">
+            <Text fontSize="14px">{formattedDate}</Text>
+            <Text
+              position="absolute"
+              top={5}
+              right={5}
+              display={post.covered ? "flex" : "none"}
+              fontSize={20}
+              fontWeight="semibold"
+              zIndex={3}
+            >
+              Covered Post
+            </Text>
+            <Text margin="0px" paddingY="0px" fontWeight="bold" fontSize="18px">
+              {post.name}
+            </Text>
+            <Text
+              margin="0px"
+              backgroundColor="#C6E3F9"
+              width="fit-content"
+              paddingX="16px"
+              paddingY="4px"
+              borderRadius="20px"
+              marginTop="5px"
+              marginBottom="10px"
+              fontSize="14px"
+              fontWeight="semibold"
+            >
+              {fosterTypeLabels[post.type]}
+            </Text>
+            <Text fontSize="14px" lineHeight="18px" color="#656565">
+              {post.description}
+            </Text>
+          </Flex>
         </Flex>
-      </Flex>
-    </Card>
+      </Card>
+      <Card
+        position="absolute"
+        width={{ lg: "52vw" }}
+        height={"100%"}
+        zIndex={2}
+        top={0}
+        right={0}
+        opacity={post.covered ? "30%" : "0%"}
+        backgroundColor={post.covered ? "#57a0d5" : "white"}
+        borderRadius="14px"
+      ></Card>
+    </Flex>
   );
 }
 

--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -58,7 +58,7 @@ function FeedPostCard(props: { post: IPost }) {
         borderStyle={"solid"}
         borderColor={"#7d7e82a5"}
         borderWidth={0.1}
-        width={{ lg: "52vw" }}
+        width="100%"
       >
         <Flex gap={{ base: "15px", lg: "20px" }}>
           {firstImage ? (

--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -2,8 +2,6 @@ import { Card, Center, Flex, Image, Text } from "@chakra-ui/react";
 import DefaultDog from "../../public/dog.svg";
 import dayjs from "dayjs";
 import { fosterTypeLabels, IPost } from "../../utils/types/post";
-import { useAuth } from "../../context/auth";
-import { Role } from "../../utils/types/account";
 
 function DefaultDogImage() {
   return (
@@ -32,11 +30,8 @@ function DefaultDogImage() {
 //   description: string;
 // };
 
-function FeedPostCard(props: { post: IPost; hideCovered: boolean }) {
-  const { post, hideCovered } = props;
-
-  const { userData } = useAuth();
-  const role = userData?.role;
+function FeedPostCard(props: { post: IPost }) {
+  const { post } = props;
 
   let firstImage;
   const imageExtensions = new Set<string>(["png", "jpeg", "jpg"]);
@@ -55,17 +50,7 @@ function FeedPostCard(props: { post: IPost; hideCovered: boolean }) {
     .toString();
 
   return (
-    <Flex
-      position="relative"
-      display={
-        ((role === Role.Admin || role === Role.ContentCreator) &&
-          (!post.covered || !hideCovered)) ||
-        (role === Role.Volunteer && !post.covered)
-          ? "flex"
-          : "none"
-      }
-      marginBottom={4}
-    >
+    <Flex position="relative" marginBottom={4}>
       <Card
         paddingX={{ base: "12px", lg: "16px" }}
         paddingY={{ base: "16px", lg: "20px" }}

--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -64,7 +64,7 @@ function FeedPostCard(props: { post: IPost; hideCovered: boolean }) {
           ? "flex"
           : "none"
       }
-      marginBottom="10px"
+      marginBottom={4}
     >
       <Card
         paddingX={{ base: "12px", lg: "16px" }}
@@ -95,7 +95,7 @@ function FeedPostCard(props: { post: IPost; hideCovered: boolean }) {
               position="absolute"
               top={5}
               right={5}
-              display={post.covered ? "flex" : "none"}
+              display={{ base: "none", lg: post.covered ? "flex" : "none" }}
               fontSize={20}
               fontWeight="semibold"
               zIndex={3}

--- a/web/components/PetPostModal/ImageSlider.tsx
+++ b/web/components/PetPostModal/ImageSlider.tsx
@@ -7,6 +7,7 @@ import DefaultDog from "../../public/dog.svg";
 function ImageSlider(props: { attachments: Array<string> }) {
   return (
     <Carousel
+      showThumbs={false}
       axis="horizontal"
       showStatus={false}
       swipeable={false}

--- a/web/components/PetPostModal/ImageSlider.tsx
+++ b/web/components/PetPostModal/ImageSlider.tsx
@@ -7,7 +7,6 @@ import DefaultDog from "../../public/dog.svg";
 function ImageSlider(props: { attachments: Array<string> }) {
   return (
     <Carousel
-      showThumbs={false}
       axis="horizontal"
       showStatus={false}
       swipeable={false}

--- a/web/components/PetPostModal/MarkCoveredButton.tsx
+++ b/web/components/PetPostModal/MarkCoveredButton.tsx
@@ -1,0 +1,111 @@
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+  useToast,
+} from "@chakra-ui/react";
+import { trpc } from "../../utils/trpc";
+import { Types } from "mongoose";
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
+
+function MarkCoveredButton(props: {
+  postId: Types.ObjectId;
+  isCovered: boolean;
+}) {
+  const { postId, isCovered } = props;
+  const mutation = trpc.post.updateStatus.useMutation();
+  const utils = trpc.useContext();
+  const toast = useToast();
+  const {
+    isOpen: isCoveredConfirmationOpen,
+    onOpen: onCoveredConfirmationOpen,
+    onClose: onCoveredConfirmationClose,
+  } = useDisclosure();
+
+  const color = isCovered ? "text-primary" : "text-secondary";
+
+  return (
+    <Flex>
+      <Button
+        h={8}
+        backgroundColor="white"
+        onClick={onCoveredConfirmationOpen}
+        _hover={{}}
+        leftIcon={
+          isCovered ? <ViewIcon color={color} /> : <ViewOffIcon color={color} />
+        }
+      >
+        <Text textDecoration="underline" color={color}>
+          {isCovered ? "Uncover Post" : "Mark as Covered"}
+        </Text>
+      </Button>
+      <Modal
+        isOpen={isCoveredConfirmationOpen}
+        onClose={onCoveredConfirmationClose}
+      >
+        <ModalOverlay />
+        <ModalContent textAlign="center" width={["85%"]}>
+          <ModalHeader marginTop={2}>
+            {isCovered ? "Uncover Post" : "Mark As Covered"}
+          </ModalHeader>
+          <ModalBody>
+            {isCovered
+              ? "Are you sure you would like to uncover this post? This post would show up on the feed if uncovered."
+              : "Are you sure you would like to mark this post as covered? This post would be hidden on the feed if covered."}
+          </ModalBody>
+          <ModalFooter justifyContent="center" marginBottom={2}>
+            <Button
+              variant="outline-secondary"
+              width={32}
+              borderRadius={16}
+              marginRight={10}
+              onClick={onCoveredConfirmationClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="solid-primary"
+              width={32}
+              borderRadius={16}
+              onClick={() => {
+                mutation.mutate(
+                  { _id: postId },
+                  {
+                    onSuccess: () => {
+                      utils.post.invalidate();
+                    },
+                    onError: () => {
+                      toast({
+                        title: "Error",
+                        description: "Changing covered status was unsuccessful",
+                        containerStyle: {
+                          whiteSpace: "pre-line",
+                        },
+                        status: "error",
+                        duration: 5000,
+                        isClosable: true,
+                        position: "top",
+                      });
+                    },
+                  }
+                );
+                onCoveredConfirmationClose();
+              }}
+            >
+              Confirm
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Flex>
+  );
+}
+
+export default MarkCoveredButton;

--- a/web/components/PetPostModal/MarkCoveredModal.tsx
+++ b/web/components/PetPostModal/MarkCoveredModal.tsx
@@ -7,45 +7,29 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Text,
-  useDisclosure,
   useToast,
 } from "@chakra-ui/react";
 import { trpc } from "../../utils/trpc";
 import { Types } from "mongoose";
-import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
 
-function MarkCoveredButton(props: {
+function MarkCoveredModal(props: {
+  isCoveredConfirmationOpen: boolean;
+  onCoveredConfirmationClose: () => void;
   postId: Types.ObjectId;
   isCovered: boolean;
 }) {
-  const { postId, isCovered } = props;
+  const {
+    isCoveredConfirmationOpen,
+    onCoveredConfirmationClose,
+    postId,
+    isCovered,
+  } = props;
   const mutation = trpc.post.updateStatus.useMutation();
   const utils = trpc.useContext();
   const toast = useToast();
-  const {
-    isOpen: isCoveredConfirmationOpen,
-    onOpen: onCoveredConfirmationOpen,
-    onClose: onCoveredConfirmationClose,
-  } = useDisclosure();
-
-  const color = isCovered ? "text-primary" : "text-secondary";
 
   return (
     <Flex>
-      <Button
-        h={8}
-        backgroundColor="white"
-        onClick={onCoveredConfirmationOpen}
-        _hover={{}}
-        leftIcon={
-          isCovered ? <ViewIcon color={color} /> : <ViewOffIcon color={color} />
-        }
-      >
-        <Text textDecoration="underline" color={color}>
-          {isCovered ? "Uncover Post" : "Mark as Covered"}
-        </Text>
-      </Button>
       <Modal
         isOpen={isCoveredConfirmationOpen}
         onClose={onCoveredConfirmationClose}
@@ -108,4 +92,4 @@ function MarkCoveredButton(props: {
   );
 }
 
-export default MarkCoveredButton;
+export default MarkCoveredModal;

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -218,7 +218,7 @@ import MarkCoveredModal from "./MarkCoveredModal";
 const PetPostModal: React.FC<{
   isOpen: boolean;
   onClose: () => void;
-  postData: IPost & { _id: Types.ObjectId } & { _id: Types.ObjectId };
+  postData: IPost & { _id: Types.ObjectId };
 }> = ({ isOpen, onClose, postData }) => {
   const {
     isOpen: isFormViewOpen,

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -15,6 +15,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Spinner,
   Stack,
   Text,
   useDisclosure,
@@ -197,7 +198,6 @@ import {
   fosterTypeLabels,
   behavioralLabels,
   spayNeuterStatusLabels,
-  IPost,
   medicalLabels,
   crateTrainedLabels,
   houseTrainedLabels,
@@ -214,12 +214,13 @@ import { Role } from "../../utils/types/account";
 import { useAuth } from "../../context/auth";
 import DeletePostModal from "./DeletePostModal";
 import MarkCoveredModal from "./MarkCoveredModal";
+import { trpc } from "../../utils/trpc";
 
 const PetPostModal: React.FC<{
   isOpen: boolean;
   onClose: () => void;
-  postData: IPost & { _id: Types.ObjectId };
-}> = ({ isOpen, onClose, postData }) => {
+  postId: Types.ObjectId;
+}> = ({ isOpen, onClose, postId }) => {
   const {
     isOpen: isFormViewOpen,
     onOpen: onFormViewOpen,
@@ -238,12 +239,32 @@ const PetPostModal: React.FC<{
     onClose: onCoveredConfirmationClose,
   } = useDisclosure();
 
+  const { data: postData, isLoading } = trpc.post.get.useQuery({ _id: postId });
+  const { userData } = useAuth();
+  const role = userData?.role;
+
+  if (isLoading) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        size={"full"}
+        onClose={onClose}
+        scrollBehavior={"inside"}
+      >
+        <ModalContent>
+          <Spinner size="xl" />
+        </ModalContent>
+      </Modal>
+    );
+  }
+
+  if (!postData) {
+    return <div>no</div>;
+  }
+
   const coveredButtonColor = postData.covered
     ? "text-primary"
     : "text-secondary";
-
-  const { userData } = useAuth();
-  const role = userData?.role;
 
   const {
     name,
@@ -388,7 +409,7 @@ const PetPostModal: React.FC<{
                   <MarkCoveredModal
                     isCoveredConfirmationOpen={isCoveredConfirmationOpen}
                     onCoveredConfirmationClose={onCoveredConfirmationClose}
-                    postId={postData._id}
+                    postId={postId}
                     isCovered={postData.covered}
                   />
                 </Button>
@@ -412,7 +433,7 @@ const PetPostModal: React.FC<{
                     isDeleteConfirmationOpen={isDeleteConfirmationOpen}
                     onDeleteConfirmationClose={onDeleteConfirmationClose}
                     onClose={onClose}
-                    postId={postData._id}
+                    postId={postId}
                   />
                 </Flex>
               )}
@@ -586,7 +607,7 @@ const PetPostModal: React.FC<{
                       isDeleteConfirmationOpen={isDeleteConfirmationOpen}
                       onDeleteConfirmationClose={onDeleteConfirmationClose}
                       onClose={onClose}
-                      postId={postData._id}
+                      postId={postId}
                     />
                   </Flex>
                 )}

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -1,4 +1,4 @@
-import { ArrowBackIcon, ViewOffIcon } from "@chakra-ui/icons";
+import { ArrowBackIcon } from "@chakra-ui/icons";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import {
   Button,
@@ -203,17 +203,24 @@ import {
   ageLabels,
   fosterTypeDescriptions,
 } from "../../utils/types/post";
+import MarkCoveredButton from "./MarkCoveredButton";
+import { Types } from "mongoose";
+import { useAuth } from "../../context/auth";
+import { Role } from "../../utils/types/account";
 
 const PetPostModal: React.FC<{
   isOpen: boolean;
   onClose: () => void;
-  postData: IPost;
+  postData: IPost & { _id: Types.ObjectId };
 }> = ({ isOpen, onClose, postData }) => {
   const {
     isOpen: isFormViewOpen,
     onOpen: onFormViewOpen,
     onClose: onFormViewClose,
   } = useDisclosure();
+
+  const { userData } = useAuth();
+  const role = userData?.role;
 
   const {
     name,
@@ -336,10 +343,12 @@ const PetPostModal: React.FC<{
             >
               Back to feed
             </Button>
-            <Button h={8}>
-              <ViewOffIcon marginRight="5px" />
-              Mark as Covered
-            </Button>
+            {(role === Role.Admin || role === Role.ContentCreator) && (
+              <MarkCoveredButton
+                postId={postData._id}
+                isCovered={postData.covered}
+              />
+            )}
           </Stack>
           <Flex direction="row" width="100%">
             <Flex

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -508,7 +508,6 @@ const PetPostModal: React.FC<{
                 </Text>
               </Stack>
             </Stack>
-
             <Stack direction="column" width="100%" spacing={4}>
               <Flex width="100%" direction={"column"}>
                 <PetPostListGroup title={"Main Characteristics"} tags={[]} />

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -1,4 +1,9 @@
-import { ArrowBackIcon, DeleteIcon } from "@chakra-ui/icons";
+import {
+  ArrowBackIcon,
+  DeleteIcon,
+  ViewIcon,
+  ViewOffIcon,
+} from "@chakra-ui/icons";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import {
   Button,
@@ -208,7 +213,7 @@ import {
 import { Role } from "../../utils/types/account";
 import { useAuth } from "../../context/auth";
 import DeletePostModal from "./DeletePostModal";
-import MarkCoveredButton from "./MarkCoveredButton";
+import MarkCoveredModal from "./MarkCoveredModal";
 
 const PetPostModal: React.FC<{
   isOpen: boolean;
@@ -226,6 +231,16 @@ const PetPostModal: React.FC<{
     onOpen: onDeleteConfirmationOpen,
     onClose: onDeleteConfirmationClose,
   } = useDisclosure();
+
+  const {
+    isOpen: isCoveredConfirmationOpen,
+    onOpen: onCoveredConfirmationOpen,
+    onClose: onCoveredConfirmationClose,
+  } = useDisclosure();
+
+  const coveredButtonColor = postData.covered
+    ? "text-primary"
+    : "text-secondary";
 
   const { userData } = useAuth();
   const role = userData?.role;
@@ -339,25 +354,44 @@ const PetPostModal: React.FC<{
           height={"inherit"}
         >
           <Stack direction="row" justifyContent="space-between">
-            <Stack direction="row" justifyContent="space-between">
-              <Button
-                h={8}
-                w="fit-content"
-                bgColor="tag-primary-bg"
-                color="text-primary"
-                marginLeft={10}
-                _hover={{ bgColor: "tag-primary-bg" }}
-                leftIcon={<ArrowBackIcon />}
-                onClick={onClose}
-                id="backToFeedButton"
-              >
-                Back to feed
-              </Button>
+            <Button
+              h={8}
+              w="fit-content"
+              bgColor="tag-primary-bg"
+              color="text-primary"
+              marginLeft={10}
+              _hover={{ bgColor: "tag-primary-bg" }}
+              leftIcon={<ArrowBackIcon />}
+              onClick={onClose}
+              id="backToFeedButton"
+            >
+              Back to feed
+            </Button>
+            <Flex>
               {(role === Role.Admin || role === Role.ContentCreator) && (
-                <MarkCoveredButton
-                  postId={postData._id}
-                  isCovered={postData.covered}
-                />
+                <Button
+                  h={8}
+                  backgroundColor="white"
+                  onClick={onCoveredConfirmationOpen}
+                  _hover={{}}
+                  leftIcon={
+                    postData.covered ? (
+                      <ViewIcon color={coveredButtonColor} />
+                    ) : (
+                      <ViewOffIcon color={coveredButtonColor} />
+                    )
+                  }
+                >
+                  <Text textDecoration="underline" color={coveredButtonColor}>
+                    {postData.covered ? "Uncover Post" : "Mark as Covered"}
+                  </Text>
+                  <MarkCoveredModal
+                    isCoveredConfirmationOpen={isCoveredConfirmationOpen}
+                    onCoveredConfirmationClose={onCoveredConfirmationClose}
+                    postId={postData._id}
+                    isCovered={postData.covered}
+                  />
+                </Button>
               )}
               {(role === Role.Admin || role === Role.ContentCreator) && (
                 <Flex>
@@ -382,7 +416,7 @@ const PetPostModal: React.FC<{
                   />
                 </Flex>
               )}
-            </Stack>
+            </Flex>
           </Stack>
           <Flex direction="row" width="100%">
             <Flex

--- a/web/components/PetPostModal/PetPostModal.tsx
+++ b/web/components/PetPostModal/PetPostModal.tsx
@@ -1,4 +1,4 @@
-import { ArrowBackIcon } from "@chakra-ui/icons";
+import { ArrowBackIcon, ViewOffIcon } from "@chakra-ui/icons";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import {
   Button,
@@ -323,18 +323,24 @@ const PetPostModal: React.FC<{
           paddingX={12}
           height={"inherit"}
         >
-          <Button
-            h={8}
-            w="fit-content"
-            bgColor="tag-primary-bg"
-            color="text-primary"
-            marginLeft={10}
-            _hover={{ bgColor: "tag-primary-bg" }}
-            leftIcon={<ArrowBackIcon />}
-            onClick={onClose}
-          >
-            Back to feed
-          </Button>
+          <Stack direction="row" justifyContent="space-between">
+            <Button
+              h={8}
+              w="fit-content"
+              bgColor="tag-primary-bg"
+              color="text-primary"
+              marginLeft={10}
+              _hover={{ bgColor: "tag-primary-bg" }}
+              leftIcon={<ArrowBackIcon />}
+              onClick={onClose}
+            >
+              Back to feed
+            </Button>
+            <Button h={8}>
+              <ViewOffIcon marginRight="5px" />
+              Mark as Covered
+            </Button>
+          </Stack>
           <Flex direction="row" width="100%">
             <Flex
               w="50%"

--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -14,11 +14,9 @@ import { captureException } from "@sentry/nextjs";
 
 type UploadInfo = Record<string, string>;
 
-async function getPost(
-  oid: Types.ObjectId,
-  publicAttachmentUrls: boolean
-): Promise<IPost & { _id: string; __v: number }> {
-  const post = await Post.findById(oid).exec();
+async function getPost(oid: Types.ObjectId, publicAttachmentUrls: boolean) {
+  const post: (IPost & { _id: Types.ObjectId; __v: number }) | null =
+    await Post.findById(oid).exec();
   if (publicAttachmentUrls && post) {
     post.attachments = post.attachments.map((attachment: string) => {
       return `${consts.storageBucketURL}/${attachment}`;
@@ -119,6 +117,9 @@ async function deleteAttachments(keysToDelete: string[]) {
 
 async function deletePost(id: Types.ObjectId) {
   const post = await getPost(id, false);
+  if (!post) {
+    throw new Error("Post to be deleted could not be found");
+  }
   try {
     await deleteAttachments(post.attachments);
   } catch (e) {

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -168,6 +168,12 @@ export const postRouter = router({
       }
       try {
         const post = await getPost(input.postOid, true);
+        if (!post) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "No post with given id exists.",
+          });
+        }
         const email = fosterTypeEmails[post.type];
         let count = 0;
         const maxTries = 3;


### PR DESCRIPTION
## Mark post as covered

Issue Number(s): #89, #184

Adds mark post as covered button (which displays confirmation when clicked) and uses API route to make changes on backend. Adds blue overlay for admin/content creator on feed for covered posts. Adds show/hide covered post button on feed filter for admin/content creator. Hides covered posts to volunteers. 

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

None

### Related PRs

None

### Testing

Admin/Content Creator:
- Toast displayed if error
- Mark as Covered and Uncover change button text & display on feed
- Show/Hide covered posts button changes feed

Volunteer:
- Buttons not visible
- Covered posts not visible on feed