### PR TITLE
Post deletion integration tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    environment: development
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           STORAGE_BUCKET_NAME: ${{ secrets.STORAGE_BUCKET_NAME }}
           STORAGE_S3_ENDPOINT: ${{ secrets.STORAGE_S3_ENDPOINT }}
-          STORAGE_S3_REGION: ${{ secrests.STORAGE_S3_REGION }}
+          STORAGE_S3_REGION: ${{ secrets.STORAGE_S3_REGION }}
           STORAGE_KEY_ID: ${{ secrets.STORAGE_KEY_ID }}
           STORAGE_APPLICATION_KEY: ${{ secrets.STORAGE_APPLICATION_KEY }}
           STORAGE_BUCKET_URL: ${{ secrets.STORAGE_BUCKET_URL }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: "coverage"
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -13,13 +13,16 @@ jobs:
       - name: Generate coverage report
         id: coverage
         uses: ArtiomTr/jest-coverage-report-action@v2
+        env:
+          STORAGE_BUCKET_NAME: ${{ secrets.STORAGE_BUCKET_NAME }}
+          STORAGE_S3_ENDPOINT: ${{ secrets.STORAGE_S3_ENDPOINT }}
+          STORAGE_S3_REGION: ${{ secrests.STORAGE_S3_REGION }}
+          STORAGE_KEY_ID: ${{ secrets.STORAGE_KEY_ID }}
+          STORAGE_APPLICATION_KEY: ${{ secrets.STORAGE_APPLICATION_KEY }}
+          STORAGE_BUCKET_URL: ${{ secrets.STORAGE_BUCKET_URL }}
         with:
           working-directory: web
           test-script: yarn jest --coverage --collectCoverageFrom='./**/*.{ts,tsx}'
           package-manager: yarn
-          output: comment, report-markdown
-
-      - name: Markdown comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: ${{ steps.coverage.outputs.report }}
+          output: comment
+          annotations: none

--- a/web/__tests__/pages/api/post/post.int.test.ts
+++ b/web/__tests__/pages/api/post/post.int.test.ts
@@ -125,6 +125,9 @@ describe("[API] Post - Integration Test", () => {
         postOid: id,
       });
       expect(res.success).toBe(true);
+
+      const post = await Post.findById(id);
+      expect(post).toBeNull();
     });
 
     test("bucket object deletion failure, expect successful post deletion", async () => {
@@ -137,6 +140,9 @@ describe("[API] Post - Integration Test", () => {
       });
       expect(spy).toHaveBeenCalledTimes(3);
       expect(res.success).toBe(true);
+
+      const post = await Post.findById(id);
+      expect(post).toBeNull();
     });
   });
 });

--- a/web/__tests__/pages/api/post/post.int.test.ts
+++ b/web/__tests__/pages/api/post/post.int.test.ts
@@ -1,152 +1,142 @@
+declare var global: any;
+
 import { readFileSync } from "fs";
 import { createRandomPost } from "../../../../db/actions/__mocks__/Post";
+import { deleteAttachments } from "../../../../db/actions/Post";
 import { consts } from "../../../../utils/consts";
 import storageClient from "../../../../db/storageConnect";
+import mongoose, { ConnectOptions } from "mongoose";
+import { appRouter } from "../../../../server/routers/_app";
+import { createContextInner } from "../../../../server/context";
+import Post from "../../../../db/models/Post";
 
 const noResizeData = readFileSync("./__tests__/assets/no-resize.png");
-const resizeData = readFileSync("./__tests__/assets/resize.png");
 const videoData = readFileSync("./__tests__/assets/video.mp4");
 
-async function sendCreateReq() {
-  const randPost = createRandomPost();
-  return fetch("http://localhost:3000/api/trpc/post.create", {
-    method: "POST",
-    body: JSON.stringify({
-      ...randPost,
-      attachments: [
-        {
-          type: "image",
-          width: 2200,
-          length: 2259,
-          key: "resizedImage",
-        },
-        {
-          type: "image",
-          width: 1000,
-          length: 842,
-          key: "nonResizedImage",
-        },
-        {
-          type: "video",
-          key: "video",
-        },
-      ],
-    }),
-  });
+// Mocks procedures without authentication session
+jest.mock("../../../../server/trpc");
+
+// Mocks context without db connection
+jest.mock("../../../../server/context");
+
+async function simulateAuthenticatedSession() {
+  const context = await createContextInner();
+  const caller = appRouter.createCaller(context);
+  return caller;
 }
 
-describe.skip("[Post] Delete Post - Integration Test", () => {
-  test("delete post and attachments with different uploads", async () => {
-    const response = await sendCreateReq();
-    expect(response.status).toBe(200);
-    const json = await response.json();
-    const attachments = json["result"]["data"]["attachments"];
-    const oid = json["result"]["data"]["_id"];
+/**
+ * Tests post API endpoints and integration with db. DB actions hit an
+ * in-memory MongoDB database. Storage bucket calls hit a development bucket.
+ *
+ * @group api/post
+ * @group api
+ * @group int
+ */
+describe("[API] Post - Integration Test", () => {
+  beforeAll(async () => {
+    mongoose
+      .connect(global.__MONGO_URI__, {
+        useNewUrlParser: true,
+      } as ConnectOptions)
+      .then(
+        (instance) => {
+          instance.connection.db.admin().command({
+            setParameter: 1,
+            maxTransactionLockRequestTimeoutMillis: 5000,
+          });
+        },
+        (err) => {
+          if (err) {
+            console.error(err);
+            process.exit(1);
+          }
+        }
+      );
+    await Post.createCollection();
+  });
 
-    // Upload no-resize
-    const resultNoResize = await fetch(attachments[`${oid}/nonResizedImage`], {
-      method: "PUT",
-      body: noResizeData,
-      headers: {
-        "Content-Length": `${noResizeData.length}`,
-      },
-    });
-    expect(resultNoResize.status).toBe(200);
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
 
-    // Upload with resize
-    const resultResize = await fetch(attachments[`${oid}/resizedImage`], {
-      method: "PUT",
-      body: resizeData,
-      headers: {
-        "Content-Length": `${resizeData.length}`,
-      },
-    });
-    expect(resultResize.status).toBe(200);
+  describe("post.delete", () => {
+    let caller: ReturnType<typeof appRouter.createCaller>;
 
-    // Upload video
-    const resultVideo = await fetch(attachments[`${oid}/video`], {
-      method: "PUT",
-      body: videoData,
-      headers: {
-        "Content-Length": `${videoData.length}`,
-      },
-    });
-    expect(resultVideo.status).toBe(200);
+    const id = new mongoose.Types.ObjectId();
+    const idString = id.toString();
+    const attachmentBodyMap = {
+      "no-resize.png": noResizeData,
+      "video.mp4": videoData,
+    } as const;
 
-    const finalize = await fetch(
-      "http://localhost:3000/api/trpc/post.finalize",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          _id: oid,
-        }),
-      }
-    );
-    expect(finalize.status).toBe(200);
+    const attachments: Array<keyof typeof attachmentBodyMap> = [
+      "no-resize.png",
+      "video.mp4",
+    ];
 
-    const postData = await finalize.json();
-    expect(postData["result"]["data"]["pending"]).toBe(false);
-
-    const testObjInfo: Record<string, any> = {
-      resizedImage: {
-        length: resizeData.length,
-        shouldEqual: false,
-      },
-      nonResizedImage: {
-        length: noResizeData.length,
-        shouldEqual: true,
-      },
-      video: {
-        length: videoData.length,
-        shouldEqual: true,
-      },
-    };
-
-    const objectInfo = await storageClient.listObjectsV2({
-      Bucket: consts.storageBucket,
-      Prefix: oid,
+    beforeAll(async () => {
+      caller = await simulateAuthenticatedSession();
     });
 
-    for (let i = 0; i < objectInfo.Contents!.length; i++) {
-      const info = objectInfo.Contents![i];
-      const testInfo = testObjInfo[info.Key!.replace(`${oid}/`, "")];
-      expect(testInfo.length === info.Size).toBe(testInfo.shouldEqual);
-    }
+    beforeEach(async () => {
+      jest.restoreAllMocks();
+      const samplePost = createRandomPost();
+      const post = await Post.create({
+        ...samplePost,
+        _id: id,
+        attachments,
+      });
+      expect(post).not.toBeNull();
 
-    //check if delete post is successful on mongoose object
-    const deletePostResponse = await fetch(
-      "http://localhost:3000/api/trpc/post.delete",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          postOid: oid,
-        }),
+      for (const attachment of attachments) {
+        const res = await storageClient.putObject({
+          Key: `${idString}/${attachment}`,
+          Bucket: consts.storageBucket,
+          Body: attachmentBodyMap[attachment],
+          ContentLength: attachmentBodyMap[attachment].length,
+        });
+        expect(res.$metadata.httpStatusCode).toBe(200);
       }
-    );
-    expect(deletePostResponse.status).toBe(200);
+      const objects = await storageClient.listObjectsV2({
+        Bucket: consts.storageBucket,
+        Prefix: idString,
+      });
 
-    const deletePostSuccess = await deletePostResponse.json();
-    expect(deletePostSuccess["result"]["data"]["success"]).toBe(true);
+      expect(objects.Contents).not.toBeUndefined();
+      expect(objects.Contents!.length).toBe(attachments.length);
+    });
 
-    const post = await fetch(
-      `http://localhost:3000/api/trpc/post.get?input={"_id":"${oid}"}`,
-      {
-        method: "GET",
-      }
-    );
-    expect(post.status).toBe(200);
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      await storageClient.deleteObjects({
+        Bucket: consts.storageBucket,
+        Delete: {
+          Objects: attachments.map((attachment) => ({
+            Key: `${id}/${attachment}`,
+          })),
+        },
+      });
+      await Post.deleteMany({});
+    });
 
-    const getPostSuccess = await post.json();
-    expect(getPostSuccess["result"]["data"]).toBe(null);
+    test("happy", async () => {
+      const res = await caller.post.delete({
+        postOid: id,
+      });
+      expect(res.success).toBe(true);
+    });
 
-    //check if attachments are all deleted in storage bucket
-    const attach = await fetch(
-      `http://localhost:3000/api/trpc/post.getAttachments?input={"_id":"${oid}"}`,
-      {
-        method: "GET",
-      }
-    );
-    const attachmentsInfo = await attach.json();
-    expect(attachmentsInfo["result"]["data"]["Contents"]).toBe(undefined);
+    test("bucket object deletion failure, expect successful post deletion", async () => {
+      const spy = jest.spyOn(storageClient, "send").mockImplementation(() => {
+        throw new Error();
+      });
+
+      const res = await caller.post.delete({
+        postOid: id,
+      });
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(res.success).toBe(true);
+    });
   });
 });

--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -1,4 +1,4 @@
-import { ClientSession, FilterQuery, ObjectId, UpdateQuery } from "mongoose";
+import { ClientSession, FilterQuery, Types, UpdateQuery } from "mongoose";
 import Post from "../models/Post";
 import { IPendingPost, IPost } from "../../utils/types/post";
 import {
@@ -15,10 +15,10 @@ import { captureException } from "@sentry/nextjs";
 type UploadInfo = Record<string, string>;
 
 async function getPost(
-  oid: ObjectId,
+  oid: Types.ObjectId,
   publicAttachmentUrls: boolean
 ): Promise<IPost & { _id: string; __v: number }> {
-  const post = await Post.findOne({ _id: oid });
+  const post = await Post.findById(oid).exec();
   if (publicAttachmentUrls && post) {
     post.attachments = post.attachments.map((attachment: string) => {
       return `${consts.storageBucketURL}/${attachment}`;
@@ -55,7 +55,7 @@ async function createPost(post: IPendingPost, session?: ClientSession) {
 }
 
 async function getAttachmentUploadURLs(
-  postId: ObjectId,
+  postId: Types.ObjectId,
   post: IPendingPost
 ): Promise<UploadInfo> {
   const attachmentURLs: Record<string, string> = {};
@@ -91,14 +91,14 @@ async function getResizedUploadUrl(uuid: string): Promise<string> {
 }
 
 async function deleteAttachments(keysToDelete: string[]) {
-  let numTries = 1;
+  let numTries = 0;
   const maxTries = 3;
   const objectsToDelete = keysToDelete.map((keyToDelete) => ({
     Key: keyToDelete,
   }));
   const deleteObjectsCommand = new DeleteObjectsCommand({
     Bucket: consts.storageBucket,
-    Delete: { Objects: objectsToDelete, Quiet: false },
+    Delete: { Objects: objectsToDelete },
   });
   while (true) {
     try {
@@ -110,26 +110,29 @@ async function deleteAttachments(keysToDelete: string[]) {
       }
     } catch (e) {
       //TODO: Write cron job to mark unsuccessful deletions to delete later
-      if (numTries++ == maxTries) {
+      if (++numTries == maxTries) {
         throw e;
       }
     }
   }
 }
 
-async function deletePost(id: ObjectId) {
+async function deletePost(id: Types.ObjectId) {
   const post = await getPost(id, false);
-  const returned = deleteAttachments(post.attachments).catch((e) =>
-    captureException(e)
-  );
-  const deletePost = await Post.deleteOne({ _id: id });
-  if (deletePost.deletedCount !== 1) {
+  try {
+    await deleteAttachments(post.attachments);
+  } catch (e) {
+    captureException(e);
+  }
+
+  const deletePost = await Post.findByIdAndDelete(id);
+  if (!deletePost) {
     throw new Error("Post document deletion failed");
   }
   return { success: true };
 }
 
-async function finalizePost(id: ObjectId, session?: ClientSession) {
+async function finalizePost(id: Types.ObjectId, session?: ClientSession) {
   const post = await Post.findOne({ _id: id });
   const uploadedObjects = await storageClient.listObjectsV2({
     Bucket: consts.storageBucket,
@@ -157,7 +160,7 @@ async function finalizePost(id: ObjectId, session?: ClientSession) {
 }
 
 async function updatePostDetails(
-  oid: ObjectId,
+  oid: Types.ObjectId,
   update: UpdateQuery<IPost>,
   session?: ClientSession
 ) {
@@ -166,7 +169,7 @@ async function updatePostDetails(
   });
 }
 
-async function updatePostStatus(oid: ObjectId, session?: ClientSession) {
+async function updatePostStatus(oid: Types.ObjectId, session?: ClientSession) {
   return await Post.findOneAndUpdate(
     { _id: oid },
     [{ $set: { covered: { $not: "$covered" } } }],
@@ -178,7 +181,7 @@ async function getAllPosts() {
   return await Post.find().sort({ date: -1 });
 }
 
-async function getAttachments(oid: ObjectId) {
+async function getAttachments(oid: Types.ObjectId) {
   const listObjectsCommand = new ListObjectsCommand({
     Bucket: consts.storageBucket,
     Prefix: oid.toString(),
@@ -208,4 +211,5 @@ export {
   getAllPosts,
   getAttachments,
   getFilteredPosts,
+  deleteAttachments,
 };

--- a/web/db/actions/__mocks__/User.ts
+++ b/web/db/actions/__mocks__/User.ts
@@ -1,4 +1,4 @@
-import { ClientSession, ObjectId, UpdateQuery } from "mongoose";
+import { ClientSession, Types, UpdateQuery } from "mongoose";
 import { faker } from "@faker-js/faker";
 import { IUser } from "../../../utils/types/user";
 import { Role } from "../../../utils/types/account";
@@ -6,7 +6,7 @@ var mongoose = require("mongoose");
 
 faker.seed(0);
 
-function createRandomUser(): IUser & { _id: ObjectId } {
+function createRandomUser(): IUser & { _id: Types.ObjectId } {
   return {
     _id: new mongoose.Types.ObjectId(),
     email: faker.internet.email(),

--- a/web/jest-mongodb-config.js
+++ b/web/jest-mongodb-config.js
@@ -8,5 +8,9 @@ module.exports = {
       skipMD5: true,
     },
     autoStart: false,
+    replSet: {
+      count: 3,
+      storageEngine: "wiredTiger",
+    },
   },
 };

--- a/web/server/__mocks__/context.ts
+++ b/web/server/__mocks__/context.ts
@@ -13,6 +13,7 @@ export const callingUser: IUser = {
   uid: faker.string.alphanumeric(28),
   role: faker.helpers.arrayElement(Object.values(Role)),
   disabled: faker.datatype.boolean(),
+  hasCompletedOnboarding: false,
 };
 
 interface CreateInnerContextOptions extends Partial<CreateNextContextOptions> {

--- a/web/server/routers/account.ts
+++ b/web/server/routers/account.ts
@@ -1,5 +1,4 @@
 import { TRPCError } from "@trpc/server";
-import { ObjectId } from "mongoose";
 import { z } from "zod";
 import {
   updateAccount,
@@ -21,8 +20,6 @@ const emailInput = {
 const searchInput = z.object({
   searchSubject: z.string(),
 });
-
-const zodOidType = z.custom<ObjectId>((item) => String(item).length == 24);
 
 export const accountRouter = router({
   modify: procedure

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -1,5 +1,4 @@
 import { TRPCError } from "@trpc/server";
-import { ObjectId } from "mongoose";
 import { z } from "zod";
 import {
   createPost,
@@ -30,8 +29,11 @@ import {
 import { findUserByEmail } from "../../db/actions/User";
 import { router, procedure } from "../trpc";
 import nodemailer from "nodemailer";
+import { Types } from "mongoose";
 
-const zodOidType = z.custom<ObjectId>((item) => String(item).length == 24);
+const zodOidType = z.custom<Types.ObjectId>(
+  (item) => String(item).length == 24
+);
 
 const postSchema = z.object({
   name: z.string(),
@@ -207,8 +209,9 @@ export const postRouter = router({
     )
     .mutation(async ({ input }) => {
       try {
-        await deletePost(input.postOid);
+        return await deletePost(input.postOid);
       } catch (e) {
+        console.error(e);
         if (e instanceof TRPCError) {
           throw e;
         } else {
@@ -218,7 +221,6 @@ export const postRouter = router({
           });
         }
       }
-      return { success: true };
     }),
   finalize: procedure
     .input(


### PR DESCRIPTION
Configures the use of replica sets in jest. Basic integration tests written for the `post.delete` API endpoint to validate the deletion of attachments upon request.