### PR TITLE
Fix covered posts shading not aligning

### DIFF
--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -102,7 +102,7 @@ function FeedPostCard(props: { post: IFeedPost }) {
       </Card>
       <Card
         position="absolute"
-        width={{ lg: "52vw" }}
+        width={{ lg: "100%" }}
         height={"100%"}
         top={0}
         right={0}

--- a/web/components/Feed/FeedPostCard.tsx
+++ b/web/components/Feed/FeedPostCard.tsx
@@ -102,7 +102,7 @@ function FeedPostCard(props: { post: IFeedPost }) {
       </Card>
       <Card
         position="absolute"
-        width={{ lg: "100%" }}
+        width={"100%"}
         height={"100%"}
         top={0}
         right={0}


### PR DESCRIPTION
## Fix covered posts shading not aligning

Issue Number(s): #244

Fixes blue shading on covered posts not aligning

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

None

### Related PRs

None

### Testing

Shading aligns when zooming in/out as well
