### PR TITLE
Fix post carousel arrow icons

### DIFF
--- a/web/components/PetPostModal/ImageSlider.tsx
+++ b/web/components/PetPostModal/ImageSlider.tsx
@@ -1,7 +1,7 @@
 import { Flex, Image, Circle } from "@chakra-ui/react";
 import { Carousel } from "react-responsive-carousel";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
-import { FaArrowCircleLeft, FaArrowCircleRight } from "react-icons/fa";
+import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import DefaultDog from "../../public/dog.svg";
 import { useState } from "react";
 
@@ -29,7 +29,12 @@ function ImageSlider(props: { attachments: Array<string> }) {
             maxHeight={["23.5vh", "35.5vh"]}
           >
             <Flex onClick={clickHandler} cursor="pointer">
-              <FaArrowCircleLeft size={30} />
+              <ChevronLeftIcon
+                boxSize={30}
+                background={"white"}
+                color={"black"}
+                borderRadius="100"
+              />
             </Flex>
           </Flex>
         );
@@ -48,7 +53,12 @@ function ImageSlider(props: { attachments: Array<string> }) {
             maxHeight={["23.5vh", "35.5vh"]}
           >
             <Flex onClick={clickHandler} cursor="pointer">
-              <FaArrowCircleRight size={30} />
+              <ChevronRightIcon
+                boxSize={30}
+                background={"white"}
+                color={"black"}
+                borderRadius="100"
+              />
             </Flex>
           </Flex>
         );

--- a/web/components/PetPostModal/ImageSlider.tsx
+++ b/web/components/PetPostModal/ImageSlider.tsx
@@ -34,6 +34,7 @@ function ImageSlider(props: { attachments: Array<string> }) {
                 background={"white"}
                 color={"black"}
                 borderRadius="100"
+                border="1px solid black"
               />
             </Flex>
           </Flex>
@@ -58,6 +59,7 @@ function ImageSlider(props: { attachments: Array<string> }) {
                 background={"white"}
                 color={"black"}
                 borderRadius="100"
+                border="1px solid black"
               />
             </Flex>
           </Flex>


### PR DESCRIPTION
## Fix post carousel arrow icons

Issue Number(s): #250

Changes post carousel arrow icons so that they don't completely disappear on white background images. Used an arrow with white background and black arrow so it shows up on all possible backgrounds.

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

None

### Related PRs

None

### Testing

Check that arrow is visible on multiple colors of backgrounds
