### PR TITLE
313 create draft pages

### DIFF
--- a/web/components/FeedPage/CoveredDropdown.tsx
+++ b/web/components/FeedPage/CoveredDropdown.tsx
@@ -1,10 +1,19 @@
 import Select from "react-select";
 
-const showingMap: Map<Array<boolean | undefined>, string> = new Map([
-  [[undefined, undefined], "all posts"],
-  [[true, undefined], "only covered posts"],
-  [[false, undefined], "only uncovered posts"],
-  [[undefined, true], "only draft posts"],
+interface PostOptions {
+  covered?: boolean | undefined;
+  draft?: boolean | undefined;
+}
+
+// TODO: there is probably a better way to do this than to stringify this.
+const showingMap: Map<string, string> = new Map([
+  [JSON.stringify({ covered: undefined, draft: undefined }), "all posts"],
+  [JSON.stringify({ covered: true, draft: undefined }), "only covered posts"],
+  [
+    JSON.stringify({ covered: false, draft: undefined }),
+    "only uncovered posts",
+  ],
+  [JSON.stringify({ covered: undefined, draft: true }), "only draft posts"],
 ]);
 
 const allDropdownOptions = Array.from(showingMap.entries()).map(([k, v]) => ({
@@ -21,11 +30,15 @@ function FeedCoveredDropdown(props: {
   ) => void;
 }) {
   const { displayCovered, displayDraft, handleCoveredChange } = props;
-
-  const displayOptions = [displayCovered, displayDraft];
-  console.log(showingMap.keys());
-  console.log(showingMap.get(displayOptions));
-  const placeholder = `Showing ${showingMap.get(displayOptions)}`;
+  console.log(displayDraft);
+  const displayOptions: PostOptions = {
+    covered: displayCovered,
+    draft: displayDraft,
+  };
+  console.log(JSON.stringify(displayOptions));
+  const placeholder = `Showing ${showingMap.get(
+    JSON.stringify(displayOptions)
+  )}`;
 
   return (
     <div>
@@ -68,7 +81,10 @@ function FeedCoveredDropdown(props: {
           (option) => option.value !== displayOptions
         )}
         onChange={(event) => {
-          handleCoveredChange(event!.value[0], event!.value[1]);
+          handleCoveredChange(
+            JSON.parse(event!.value).covered,
+            JSON.parse(event!.value).draft
+          );
         }}
       />
     </div>

--- a/web/components/FeedPage/CoveredDropdown.tsx
+++ b/web/components/FeedPage/CoveredDropdown.tsx
@@ -1,9 +1,10 @@
 import Select from "react-select";
 
-const showingMap: Map<boolean | undefined, string> = new Map([
-  [undefined, "all posts"],
-  [true, "only covered posts"],
-  [false, "only uncovered posts"],
+const showingMap: Map<Array<boolean | undefined>, string> = new Map([
+  [[undefined, undefined], "all posts"],
+  [[true, undefined], "only covered posts"],
+  [[false, undefined], "only uncovered posts"],
+  [[undefined, true], "only draft posts"],
 ]);
 
 const allDropdownOptions = Array.from(showingMap.entries()).map(([k, v]) => ({
@@ -13,55 +14,64 @@ const allDropdownOptions = Array.from(showingMap.entries()).map(([k, v]) => ({
 
 function FeedCoveredDropdown(props: {
   displayCovered: boolean | undefined;
-  handleCoveredChange: (newVal: boolean | undefined) => void;
+  displayDraft: boolean | undefined;
+  handleCoveredChange: (
+    covered: boolean | undefined,
+    draft: boolean | undefined
+  ) => void;
 }) {
-  const { displayCovered, handleCoveredChange } = props;
+  const { displayCovered, displayDraft, handleCoveredChange } = props;
 
-  const placeholder = `Showing ${showingMap.get(displayCovered)}`;
+  const displayOptions = [displayCovered, displayDraft];
+  console.log(showingMap.keys());
+  console.log(showingMap.get(displayOptions));
+  const placeholder = `Showing ${showingMap.get(displayOptions)}`;
 
   return (
-    <Select
-      controlShouldRenderValue={false}
-      placeholder={placeholder}
-      isSearchable={false}
-      isClearable={false}
-      menuPortalTarget={document.body}
-      styles={{
-        menu: (provided) => ({
-          ...provided,
-          zIndex: 9999,
-        }),
-        menuPortal: (provided) => ({
-          ...provided,
-          zIndex: 9999,
-        }),
-        control: (baseStyles) => ({
-          ...baseStyles,
-          minWidth: 200,
-          border: "1px solid #D9D9D9",
-          boxShadow: "none",
-          "&:hover": { border: "1px solid gray" },
-          borderRadius: "10px",
-          padding: 0,
-        }),
-        option: (provided, state) => ({
-          ...provided,
-          backgroundColor: state.isSelected ? "#57a0d5" : "white",
-          "&:hover": { backgroundColor: "#c6e3f9" },
-          fontSize: "14px",
-        }),
-        placeholder: (baseStyles) => ({
-          ...baseStyles,
-          fontSize: "14px",
-        }),
-      }}
-      options={allDropdownOptions.filter(
-        (option) => option.value !== displayCovered
-      )}
-      onChange={(event) => {
-        handleCoveredChange(event!.value);
-      }}
-    />
+    <div>
+      <Select
+        controlShouldRenderValue={false}
+        placeholder={placeholder}
+        isSearchable={false}
+        isClearable={false}
+        menuPortalTarget={document.body}
+        styles={{
+          menu: (provided) => ({
+            ...provided,
+            zIndex: 9999,
+          }),
+          menuPortal: (provided) => ({
+            ...provided,
+            zIndex: 9999,
+          }),
+          control: (baseStyles) => ({
+            ...baseStyles,
+            minWidth: 200,
+            border: "1px solid #D9D9D9",
+            boxShadow: "none",
+            "&:hover": { border: "1px solid gray" },
+            borderRadius: "10px",
+            padding: 0,
+          }),
+          option: (provided, state) => ({
+            ...provided,
+            backgroundColor: state.isSelected ? "#57a0d5" : "white",
+            "&:hover": { backgroundColor: "#c6e3f9" },
+            fontSize: "14px",
+          }),
+          placeholder: (baseStyles) => ({
+            ...baseStyles,
+            fontSize: "14px",
+          }),
+        }}
+        options={allDropdownOptions.filter(
+          (option) => option.value !== displayOptions
+        )}
+        onChange={(event) => {
+          handleCoveredChange(event!.value[0], event!.value[1]);
+        }}
+      />
+    </div>
   );
 }
 

--- a/web/components/FeedPage/CoveredDropdown.tsx
+++ b/web/components/FeedPage/CoveredDropdown.tsx
@@ -1,19 +1,11 @@
 import Select from "react-select";
 
-interface PostOptions {
-  covered?: boolean | undefined;
-  draft?: boolean | undefined;
-}
-
 // TODO: there is probably a better way to do this than to stringify this.
 const showingMap: Map<string, string> = new Map([
-  [JSON.stringify({ covered: undefined, draft: undefined }), "all posts"],
-  [JSON.stringify({ covered: true, draft: undefined }), "only covered posts"],
-  [
-    JSON.stringify({ covered: false, draft: undefined }),
-    "only uncovered posts",
-  ],
-  [JSON.stringify({ covered: undefined, draft: true }), "only draft posts"],
+  [JSON.stringify({}), "all posts"],
+  [JSON.stringify({ covered: true }), "only covered posts"],
+  [JSON.stringify({ covered: false }), "only uncovered posts"],
+  [JSON.stringify({ draft: true }), "only draft posts"],
 ]);
 
 const allDropdownOptions = Array.from(showingMap.entries()).map(([k, v]) => ({
@@ -30,15 +22,11 @@ function FeedCoveredDropdown(props: {
   ) => void;
 }) {
   const { displayCovered, displayDraft, handleCoveredChange } = props;
-  console.log(displayDraft);
-  const displayOptions: PostOptions = {
-    covered: displayCovered,
+  const displayOptions = JSON.stringify({
+    covered: displayCovered ?? undefined,
     draft: displayDraft,
-  };
-  console.log(JSON.stringify(displayOptions));
-  const placeholder = `Showing ${showingMap.get(
-    JSON.stringify(displayOptions)
-  )}`;
+  });
+  const placeholder = `Showing ${showingMap.get(displayOptions)}`;
 
   return (
     <div>

--- a/web/components/FeedPage/Feed/FeedPostCard.tsx
+++ b/web/components/FeedPage/Feed/FeedPostCard.tsx
@@ -109,20 +109,22 @@ function FeedPostCard(props: { post: IFeedPost }) {
             <Text margin="0px" paddingY="0px" fontWeight="bold" fontSize="18px">
               {post.name}
             </Text>
-            <Text
-              margin="0px"
-              backgroundColor="#C6E3F9"
-              width="fit-content"
-              paddingX="16px"
-              paddingY="4px"
-              borderRadius="20px"
-              marginTop="5px"
-              marginBottom="10px"
-              fontSize="14px"
-              fontWeight="semibold"
-            >
-              {fosterTypeLabels[post.type]}
-            </Text>
+            {fosterTypeLabels[post.type] && (
+              <Text
+                margin="0px"
+                backgroundColor="#C6E3F9"
+                width="fit-content"
+                paddingX="16px"
+                paddingY="4px"
+                borderRadius="20px"
+                marginTop="5px"
+                marginBottom="10px"
+                fontSize="14px"
+                fontWeight="semibold"
+              >
+                {fosterTypeLabels[post.type]}
+              </Text>
+            )}
             <Text
               fontSize="14px"
               lineHeight="18px"

--- a/web/components/FeedPage/Feed/FeedPostCard.tsx
+++ b/web/components/FeedPage/Feed/FeedPostCard.tsx
@@ -85,6 +85,17 @@ function FeedPostCard(props: { post: IFeedPost }) {
               position="absolute"
               top={5}
               right={5}
+              display={{ base: "none", lg: post.draft ? "flex" : "none" }}
+              fontSize={20}
+              fontWeight="semibold"
+              zIndex={3}
+            >
+              Draft
+            </Text>
+            <Text
+              position="absolute"
+              top={5}
+              right={5}
               display={{
                 base: "none",
                 lg: post.userAppliedTo && !post.covered ? "flex" : "none",

--- a/web/components/FeedPage/Feed/FeedSection.tsx
+++ b/web/components/FeedPage/Feed/FeedSection.tsx
@@ -17,7 +17,11 @@ import FeedPostCard from "./FeedPostCard";
 
 interface Props {
   coveredState: boolean | undefined;
-  handleCoveredChange: (newVal: boolean | undefined) => void;
+  draftState: boolean | undefined;
+  handleCoveredChange: (
+    covered: boolean | undefined,
+    draft: boolean | undefined
+  ) => void;
   onPostCreationOpen: () => void;
   isLoading: boolean;
   feedPosts: IFeedPost[] | undefined;
@@ -25,6 +29,7 @@ interface Props {
 function FeedSection(props: Props) {
   const {
     coveredState,
+    draftState,
     handleCoveredChange,
     onPostCreationOpen,
     isLoading,
@@ -69,6 +74,7 @@ function FeedSection(props: Props) {
           >
             <FeedCoveredDropdown
               displayCovered={coveredState}
+              displayDraft={draftState}
               handleCoveredChange={handleCoveredChange}
             />
           </Flex>

--- a/web/components/FeedPage/Feed/FeedSection.tsx
+++ b/web/components/FeedPage/Feed/FeedSection.tsx
@@ -36,6 +36,8 @@ function FeedSection(props: Props) {
     feedPosts,
   } = props;
 
+  console.log(feedPosts);
+
   const { userData } = useAuth();
   const role = userData?.role;
 

--- a/web/components/FeedPage/Feed/FeedSection.tsx
+++ b/web/components/FeedPage/Feed/FeedSection.tsx
@@ -36,8 +36,6 @@ function FeedSection(props: Props) {
     feedPosts,
   } = props;
 
-  console.log(feedPosts);
-
   const { userData } = useAuth();
   const role = userData?.role;
 

--- a/web/components/FeedPage/FeedPage.tsx
+++ b/web/components/FeedPage/FeedPage.tsx
@@ -252,8 +252,6 @@ function FeedPage() {
 
   const { data: feedPosts, isLoading } =
     trpc.post.getFilteredPosts.useQuery(debouncedFilters);
-
-  console.log(feedPosts);
   /**
    * Handles all changes to filter state, except for `covered`. This includes
    * option selection/deselection, dropdown modifications, reset,

--- a/web/components/FeedPage/FeedPage.tsx
+++ b/web/components/FeedPage/FeedPage.tsx
@@ -56,6 +56,7 @@ export type QueryFilter = {
 type FilterAPIInput = {
   postFilters: QueryFilter;
   covered?: boolean;
+  draft?: boolean;
 };
 
 type OptHandler<T extends FilterKeyTypeMap[FilterKeys]> = (
@@ -160,6 +161,7 @@ export const postFilterSchema = z.object({
 const feedFilterSchema = postFilterSchema.merge(
   z.object({
     covered: z.optional(z.boolean()),
+    draft: z.optional(z.boolean()),
   })
 );
 
@@ -214,6 +216,7 @@ const defaultQueryParams = {
   goodWith: withDefault(ArrayParam, []),
   behavioral: withDefault(ArrayParam, Object.keys(BEHAVIORAL_OPTION_MAP)),
   covered: withDefault(BooleanParam, undefined),
+  draft: withDefault(BooleanParam, undefined),
 };
 
 function FeedPage() {
@@ -233,10 +236,13 @@ function FeedPage() {
 
   const validatedFilters = useMemo(() => {
     const parsedFilters = parseFeedFilter(query);
+    ``;
     return {
       postFilters: parsedFilters.postFilters,
       covered:
         role === Role.Volunteer ? false : parsedFilters.covered ?? undefined,
+      draft:
+        role === Role.Volunteer ? undefined : parsedFilters.draft ?? undefined,
     };
   }, [query]);
 
@@ -294,9 +300,13 @@ function FeedPage() {
     [validatedFilters]
   );
 
-  function handleCoveredChange(newVal: boolean | undefined) {
+  function handleCoveredChange(
+    covered: boolean | undefined,
+    draft: boolean | undefined
+  ) {
     setQuery({
-      covered: newVal,
+      covered: covered,
+      draft: draft,
     });
   }
 
@@ -304,6 +314,7 @@ function FeedPage() {
     return (
       <FeedCoveredDropdown
         displayCovered={validatedFilters.covered}
+        displayDraft={validatedFilters.draft}
         handleCoveredChange={handleCoveredChange}
       />
     );
@@ -384,6 +395,7 @@ function FeedPage() {
           <FeedSection
             isLoading={isUpdating || isLoading}
             coveredState={validatedFilters.covered}
+            draftState={validatedFilters.draft}
             handleCoveredChange={handleCoveredChange}
             onPostCreationOpen={onPostCreationOpen}
             feedPosts={feedPosts}

--- a/web/components/FeedPage/FeedPage.tsx
+++ b/web/components/FeedPage/FeedPage.tsx
@@ -200,6 +200,7 @@ export type HandleFilterChangeActions =
  */
 function parseFeedFilter(query: Record<string, any>): FilterAPIInput {
   const result = feedFilterSchema.safeParse(query);
+  console.log(result);
   if (!result.success) {
     throw new Error("Could not parse URL");
   }

--- a/web/components/FeedPage/FeedPage.tsx
+++ b/web/components/FeedPage/FeedPage.tsx
@@ -252,6 +252,8 @@ function FeedPage() {
 
   const { data: feedPosts, isLoading } =
     trpc.post.getFilteredPosts.useQuery(debouncedFilters);
+
+  console.log(feedPosts);
   /**
    * Handles all changes to filter state, except for `covered`. This includes
    * option selection/deselection, dropdown modifications, reset,

--- a/web/components/FeedPage/FeedPage.tsx
+++ b/web/components/FeedPage/FeedPage.tsx
@@ -200,12 +200,11 @@ export type HandleFilterChangeActions =
  */
 function parseFeedFilter(query: Record<string, any>): FilterAPIInput {
   const result = feedFilterSchema.safeParse(query);
-  console.log(result);
   if (!result.success) {
     throw new Error("Could not parse URL");
   }
-  const { covered, ...postFilters } = result.data;
-  return { covered, postFilters };
+  const { covered, draft, ...postFilters } = result.data;
+  return { covered, draft, postFilters };
 }
 
 const defaultQueryParams = {
@@ -242,8 +241,7 @@ function FeedPage() {
       postFilters: parsedFilters.postFilters,
       covered:
         role === Role.Volunteer ? false : parsedFilters.covered ?? undefined,
-      draft:
-        role === Role.Volunteer ? undefined : parsedFilters.draft ?? undefined,
+      draft: role === Role.Volunteer ? false : parsedFilters.draft ?? undefined,
     };
   }, [query]);
 
@@ -254,7 +252,6 @@ function FeedPage() {
 
   const { data: feedPosts, isLoading } =
     trpc.post.getFilteredPosts.useQuery(debouncedFilters);
-
   /**
    * Handles all changes to filter state, except for `covered`. This includes
    * option selection/deselection, dropdown modifications, reset,

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -114,6 +114,7 @@ const formSchema = z.object({
   getsAlongWithLargeDogs: z.nativeEnum(Trained),
   getsAlongWithSmallDogs: z.nativeEnum(Trained),
   getsAlongWithCats: z.nativeEnum(Trained),
+  draft: z.boolean(),
 });
 
 export type FormState = z.input<typeof formSchema>;
@@ -145,6 +146,7 @@ const EditPostModal: React.FC<{
     type,
     size,
     age,
+    draft,
     spayNeuterStatus,
     houseTrained,
     crateTrained,
@@ -170,6 +172,7 @@ const EditPostModal: React.FC<{
     type,
     size,
     breed,
+    draft,
     temperament,
     spayNeuterStatus,
     houseTrained,
@@ -382,6 +385,33 @@ const EditPostModal: React.FC<{
             }}
           >
             Cancel
+          </Button>
+          <Button
+            size="lg"
+            isLoading={isLoading}
+            _hover={isLoading ? {} : undefined}
+            variant={fileArr.length > 0 ? "solid-primary" : "outline-primary"}
+            onClick={() => {
+              //TODO: Wait for success to close.
+              setIsLoading(true);
+              dispatch({
+                type: "setField",
+                key: "draft",
+                data: true,
+              });
+              editPost()
+                .then(() => {
+                  onClose();
+                  setFileArr(fileArr);
+                  setIsContentView(true);
+                  dispatch({
+                    type: "clear",
+                  });
+                })
+                .finally(() => setIsLoading(false));
+            }}
+          >
+            Save as Draft
           </Button>
           <Button
             size="lg"

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -493,10 +493,10 @@ const EditPostModal: React.FC<{
                     setIsContentView(false);
                   }
                 : () => {
-                    setIsLoading(true);
                     //TODO: Wait for success to close.
                     const validation = formSchema.safeParse(formState);
                     if (validation.success) {
+                      setIsLoading(true);
                       editPost(!formState.draft)
                         .then(() => {
                           onClose();

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -443,6 +443,11 @@ const EditPostModal: React.FC<{
                 : () => {
                     //TODO: Wait for success to close.
                     setIsLoading(true);
+                    dispatch({
+                      type: "setField",
+                      key: "draft",
+                      data: false,
+                    });
                     editPost()
                       .then(() => {
                         onClose();

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -462,6 +462,7 @@ const EditPostModal: React.FC<{
           </Button>
           <Button
             size="lg"
+            mr={4}
             isLoading={isLoading}
             _hover={isLoading ? {} : undefined}
             variant={fileArr.length > 0 ? "solid-primary" : "outline-primary"}
@@ -489,9 +490,25 @@ const EditPostModal: React.FC<{
             onClick={
               isContentView
                 ? () => {
+                    setIsContentView(false);
+                  }
+                : () => {
+                    setIsLoading(true);
+                    //TODO: Wait for success to close.
                     const validation = formSchema.safeParse(formState);
                     if (validation.success) {
-                      setIsContentView(false);
+                      editPost(!formState.draft)
+                        .then(() => {
+                          onClose();
+                          setFileArr(fileArr);
+                          setIsContentView(true);
+                          dispatch({
+                            type: "clear",
+                          });
+                        })
+                        .finally(() => {
+                          setIsLoading(false);
+                        });
                     } else {
                       toast.closeAll();
                       toast({
@@ -509,24 +526,9 @@ const EditPostModal: React.FC<{
                       });
                     }
                   }
-                : () => {
-                    //TODO: Wait for success to close.
-                    setIsLoading(true);
-
-                    editPost(false)
-                      .then(() => {
-                        onClose();
-                        setFileArr(fileArr);
-                        setIsContentView(true);
-                        dispatch({
-                          type: "clear",
-                        });
-                      })
-                      .finally(() => setIsLoading(false));
-                  }
             }
           >
-            {isContentView ? "Next" : "Save"}
+            {isContentView ? "Next" : "Post"}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -446,7 +446,7 @@ const EditPostModal: React.FC<{
                     dispatch({
                       type: "setField",
                       key: "draft",
-                      data: false,
+                      data: undefined,
                     });
                     editPost()
                       .then(() => {

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -470,6 +470,7 @@ const EditPostModal: React.FC<{
               setIsLoading(true);
               editDraftPost(true)
                 .then(() => {
+                  onClose();
                   setFileArr(fileArr);
                   setIsContentView(true);
                   dispatch({

--- a/web/components/PostCreationModal/PostCreationModal.tsx
+++ b/web/components/PostCreationModal/PostCreationModal.tsx
@@ -430,10 +430,10 @@ const PostCreationModal: React.FC<{
                     setIsContentView(false);
                   }
                 : () => {
-                    setLoading(true);
                     //TODO: Wait for success to close.
                     const validation = formSchema.safeParse(formState);
                     if (validation.success) {
+                      setLoading(true);
                       createPost()
                         .then(() => {
                           utils.post.invalidate();

--- a/web/components/PostCreationModal/PostCreationModal.tsx
+++ b/web/components/PostCreationModal/PostCreationModal.tsx
@@ -323,6 +323,15 @@ const PostCreationModal: React.FC<{
             isLoading={loading}
             _hover={loading ? {} : undefined}
             variant={fileArr.length > 0 ? "solid-primary" : "outline-primary"}
+            //TODO write the onClick
+          >
+            Save as Draft
+          </Button>
+          <Button
+            size="lg"
+            isLoading={loading}
+            _hover={loading ? {} : undefined}
+            variant={fileArr.length > 0 ? "solid-primary" : "outline-primary"}
             onClick={
               isContentView
                 ? () => {

--- a/web/components/PostCreationModal/PostCreationModal.tsx
+++ b/web/components/PostCreationModal/PostCreationModal.tsx
@@ -269,6 +269,7 @@ const PostCreationModal: React.FC<{
     try {
       const creationInfo = await postCreate.mutateAsync({
         ...(formState as z.output<typeof formSchema>),
+        draft: true,
         attachments: files,
       });
       const oid = creationInfo._id;
@@ -381,14 +382,9 @@ const PostCreationModal: React.FC<{
             isLoading={loading}
             _hover={loading ? {} : undefined}
             variant={fileArr.length > 0 ? "solid-primary" : "outline-primary"}
-            onClick={() => {
+            onClick={async () => {
               setLoading(true);
               //TODO: Wait for success to close.
-              dispatch({
-                type: "setField",
-                key: "draft",
-                data: true,
-              });
               createDraftPost()
                 .then(() => {
                   utils.post.invalidate();

--- a/web/components/PostCreationModal/PostCreationModal.tsx
+++ b/web/components/PostCreationModal/PostCreationModal.tsx
@@ -118,6 +118,21 @@ const formSchema = z.object({
   draft: z.boolean(),
 });
 
+const draftFormSchema = formSchema.extend({
+  description: z.string(),
+  gender: z
+    .nativeEnum(Gender, { required_error: "Gender required." })
+    .nullable(),
+  age: z.nativeEnum(Age, { required_error: "Age required." }).nullable(),
+  type: z
+    .nativeEnum(FosterType, {
+      required_error: "Foster type required.",
+    })
+    .nullable(),
+  size: z.nativeEnum(Size, { required_error: "Size required." }).nullable(),
+  breed: z.array(z.nativeEnum(Breed)),
+});
+
 export type FormState = z.input<typeof formSchema>;
 
 export type Action<K extends keyof FormState, V extends FormState[K]> = {
@@ -181,6 +196,7 @@ const PostCreationModal: React.FC<{
   const [formState, dispatch] = useReducer(reducer, defaultFormState);
 
   const postCreate = trpc.post.create.useMutation();
+  const postDraftCreate = trpc.post.draft.useMutation();
   const postFinalize = trpc.post.finalize.useMutation();
 
   const createPost = async () => {
@@ -267,8 +283,8 @@ const PostCreationModal: React.FC<{
       })
     );
     try {
-      const creationInfo = await postCreate.mutateAsync({
-        ...(formState as z.output<typeof formSchema>),
+      const creationInfo = await postDraftCreate.mutateAsync({
+        ...(formState as z.output<typeof draftFormSchema>),
         draft: true,
         attachments: files,
       });

--- a/web/components/PostCreationModal/PostCreationModal.tsx
+++ b/web/components/PostCreationModal/PostCreationModal.tsx
@@ -396,6 +396,7 @@ const PostCreationModal: React.FC<{
           <Button
             size="lg"
             isLoading={loading}
+            mr={4}
             _hover={loading ? {} : undefined}
             variant={fileArr.length > 0 ? "solid-primary" : "outline-primary"}
             onClick={async () => {
@@ -426,9 +427,26 @@ const PostCreationModal: React.FC<{
             onClick={
               isContentView
                 ? () => {
+                    setIsContentView(false);
+                  }
+                : () => {
+                    setLoading(true);
+                    //TODO: Wait for success to close.
                     const validation = formSchema.safeParse(formState);
                     if (validation.success) {
-                      setIsContentView(false);
+                      createPost()
+                        .then(() => {
+                          utils.post.invalidate();
+                          setFileArr([]);
+                          setIsContentView(true);
+                          dispatch({
+                            type: "clear",
+                          });
+                          onClose();
+                        })
+                        .finally(() => {
+                          setLoading(false);
+                        });
                     } else {
                       toast.closeAll();
                       toast({
@@ -445,23 +463,6 @@ const PostCreationModal: React.FC<{
                         position: "top",
                       });
                     }
-                  }
-                : () => {
-                    setLoading(true);
-                    //TODO: Wait for success to close.
-                    createPost()
-                      .then(() => {
-                        utils.post.invalidate();
-                        setFileArr([]);
-                        setIsContentView(true);
-                        dispatch({
-                          type: "clear",
-                        });
-                        onClose();
-                      })
-                      .finally(() => {
-                        setLoading(false);
-                      });
                   }
             }
           >

--- a/web/db/models/Post.ts
+++ b/web/db/models/Post.ts
@@ -12,39 +12,39 @@ import {
   Behavioral,
   Trained,
   Status,
+  IDraftPost,
 } from "../../utils/types/post";
 const { Schema } = mongoose;
 
-const postSchema = new Schema<IPost>({
+const postSchema = new Schema<IPost | IDraftPost>({
   date: { type: Date, default: Date.now },
   name: { type: String, required: true },
-  description: { type: String, required: true },
+  description: { type: String },
   type: {
     type: String,
-    required: true,
-    enum: Object.values(FosterType),
+    default: null,
+    enum: [...Object.values(FosterType), null],
   },
   size: {
     type: String,
-    required: true,
-    enum: Object.values(Size),
+    default: null,
+    enum: [...Object.values(Size), null],
   },
   breed: [
     {
       type: String,
-      required: true,
       enum: Object.values(Breed),
     },
   ],
   gender: {
     type: String,
-    required: true,
-    enum: Object.values(Gender),
+    default: null,
+    enum: [...Object.values(Gender), null],
   },
   age: {
     type: String,
-    required: true,
-    enum: Object.values(Age),
+    default: null,
+    enum: [...Object.values(Age), null],
   },
   temperament: [
     {

--- a/web/db/models/Post.ts
+++ b/web/db/models/Post.ts
@@ -133,6 +133,11 @@ const postSchema = new Schema<IPost>({
     default: [],
     required: true,
   },
+  isDraft: {
+    type: Boolean,
+    default: false,
+    required: true,
+  },
 });
 
 export default mongoose.models.Post || mongoose.model("Post", postSchema);

--- a/web/db/models/Post.ts
+++ b/web/db/models/Post.ts
@@ -118,6 +118,10 @@ const postSchema = new Schema<IPost>({
     type: Boolean,
     default: false,
   },
+  draft: {
+    type: Boolean,
+    default: undefined,
+  },
   pending: {
     type: Boolean,
     default: true,
@@ -131,11 +135,6 @@ const postSchema = new Schema<IPost>({
   usersAppliedTo: {
     type: [{ type: String }], // Firebase UID
     default: [],
-    required: true,
-  },
-  isDraft: {
-    type: Boolean,
-    default: false,
     required: true,
   },
 });

--- a/web/pages/post/[postId].tsx
+++ b/web/pages/post/[postId].tsx
@@ -118,12 +118,14 @@ function PostPage({
   }
 
   const postId = new Types.ObjectId(postData._id);
+  console.log(postData);
   const {
     name,
     description,
     type,
     size,
     age,
+    draft,
     spayNeuterStatus,
     behavioral,
     temperament,
@@ -248,28 +250,30 @@ function PostPage({
                   postData={postData}
                   attachments={attachments}
                 />
-                <Button
-                  variant="link"
-                  h={8}
-                  onClick={onCoveredConfirmationOpen}
-                  leftIcon={
-                    postData.covered ? (
-                      <ViewIcon color={coveredButtonColor} />
-                    ) : (
-                      <ViewOffIcon color={coveredButtonColor} />
-                    )
-                  }
-                >
-                  <Text textDecoration="underline" color={coveredButtonColor}>
-                    {postData.covered ? "Uncover Post" : "Mark as Covered"}
-                  </Text>
-                  <MarkCoveredModal
-                    isCoveredConfirmationOpen={isCoveredConfirmationOpen}
-                    onCoveredConfirmationClose={onCoveredConfirmationClose}
-                    postId={postId}
-                    isCovered={postData.covered}
-                  />
-                </Button>
+                {!draft && (
+                  <Button
+                    variant="link"
+                    h={8}
+                    onClick={onCoveredConfirmationOpen}
+                    leftIcon={
+                      postData.covered ? (
+                        <ViewIcon color={coveredButtonColor} />
+                      ) : (
+                        <ViewOffIcon color={coveredButtonColor} />
+                      )
+                    }
+                  >
+                    <Text textDecoration="underline" color={coveredButtonColor}>
+                      {postData.covered ? "Uncover Post" : "Mark as Covered"}
+                    </Text>
+                    <MarkCoveredModal
+                      isCoveredConfirmationOpen={isCoveredConfirmationOpen}
+                      onCoveredConfirmationClose={onCoveredConfirmationClose}
+                      postId={postId}
+                      isCovered={postData.covered}
+                    />
+                  </Button>
+                )}
                 <Button
                   variant="link"
                   h={8}

--- a/web/pages/post/[postId].tsx
+++ b/web/pages/post/[postId].tsx
@@ -118,7 +118,6 @@ function PostPage({
   }
 
   const postId = new Types.ObjectId(postData._id);
-  console.log(postData);
   const {
     name,
     description,

--- a/web/pages/post/[postId].tsx
+++ b/web/pages/post/[postId].tsx
@@ -320,10 +320,12 @@ function PostPage({
               About
             </Text>
             <Text>{description}</Text>
-            <Text>
-              I am a <b>{fosterTypeLabels[type].toLowerCase()}</b> dog.{" "}
-              {fosterTypeDescriptions[type]}
-            </Text>
+            {fosterTypeLabels[type] && (
+              <Text>
+                I am a <b>{fosterTypeLabels[type].toLowerCase()}</b> dog.{" "}
+                {fosterTypeDescriptions[type]}
+              </Text>
+            )}
           </Box>
           <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={5}>
             <GridItem>
@@ -432,7 +434,7 @@ function PostPage({
           colSpan={{ base: 1, md: 2 }}
         >
           <Button
-            isDisabled={postData.userAppliedTo}
+            isDisabled={postData.userAppliedTo || postData.draft}
             variant={
               postData.userAppliedTo ? "solid-secondary" : "solid-primary"
             }
@@ -451,16 +453,22 @@ function PostPage({
                   }
             }
           >
-            {postData.userAppliedTo ? "Applied" : "Foster Me!"}
+            {postData.userAppliedTo
+              ? "Applied"
+              : postData.draft
+              ? "This is a Draft"
+              : "Foster Me!"}
           </Button>
         </GridItem>
       </Grid>
-      <FosterQuestionnaire
-        fosterType={type}
-        postId={postId}
-        isFormViewOpen={isFormViewOpen}
-        onFormViewClose={onFormViewClose}
-      />
+      {!postData.draft && (
+        <FosterQuestionnaire
+          fosterType={type}
+          postId={postId}
+          isFormViewOpen={isFormViewOpen}
+          onFormViewClose={onFormViewClose}
+        />
+      )}
     </>
   );
 }

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -295,7 +295,6 @@ export const postRouter = router({
           ...input.updateFields,
           date: existingPost.date,
           covered: existingPost.covered,
-          draft: existingPost.draft,
           usersAppliedTo: existingPost.usersAppliedTo,
         });
         return newPost;
@@ -358,6 +357,7 @@ export const postRouter = router({
       z.object({
         postFilters: postFilterSchema,
         covered: z.optional(z.boolean()),
+        draft: z.optional(z.boolean()),
       })
     )
     .query(async ({ input, ctx }) => {
@@ -412,6 +412,10 @@ export const postRouter = router({
       };
       if (input.covered !== undefined) {
         baseFilter.covered = input.covered;
+      }
+
+      if (input.draft !== undefined) {
+        baseFilter.draft = input.draft;
       }
 
       try {

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -54,6 +54,7 @@ const postSchema = z.object({
   breed: z.array(z.nativeEnum(Breed)),
   gender: z.nativeEnum(Gender),
   age: z.nativeEnum(Age),
+  draft: z.boolean(),
   temperament: z.array(z.nativeEnum(Temperament)),
   medical: z.array(z.nativeEnum(Medical)),
   behavioral: z.array(z.nativeEnum(Behavioral)),
@@ -140,7 +141,6 @@ export const postRouter = router({
           date: new Date(),
           covered: false,
           usersAppliedTo: [],
-          isDraft: false,
         },
         session
       );
@@ -295,8 +295,8 @@ export const postRouter = router({
           ...input.updateFields,
           date: existingPost.date,
           covered: existingPost.covered,
+          draft: existingPost.draft,
           usersAppliedTo: existingPost.usersAppliedTo,
-          isDraft: false,
         });
         return newPost;
       } catch (e) {

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -27,6 +27,7 @@ import {
   Behavioral,
   Trained,
   IPost,
+  IDraftPost,
 } from "../../utils/types/post";
 import { findUserByEmail, updateUserByUid } from "../../db/actions/User";
 import { router, procedure } from "../trpc";
@@ -85,28 +86,12 @@ const postSchema = z.object({
   ),
 });
 
-const draftPostSchema = postSchema.partial({
-  name: true,
-  description: true,
-  type: true,
-  size: true,
-  breed: true,
-  gender: true,
-  age: true,
-  draft: true,
-  temperament: true,
-  medical: true,
-  behavioral: true,
-  houseTrained: true,
-  crateTrained: true,
-  spayNeuterStatus: true,
-  getsAlongWithMen: true,
-  getsAlongWithWomen: true,
-  getsAlongWithOlderKids: true,
-  getsAlongWithYoungKids: true,
-  getsAlongWithLargeDogs: true,
-  getsAlongWithSmallDogs: true,
-  getsAlongWithCats: true,
+const draftPostSchema = postSchema.extend({
+  type: z.nativeEnum(FosterType).nullable(),
+  size: z.nativeEnum(Size).nullable(),
+  breed: z.array(z.nativeEnum(Breed)).nullable(),
+  gender: z.nativeEnum(Gender).nullable(),
+  age: z.nativeEnum(Age).nullable(),
 });
 
 const fosterTypeEmails: Record<FosterType, string> = {
@@ -435,13 +420,13 @@ export const postRouter = router({
           };
         }
       }, {});
-
-      const baseFilter: FilterQuery<IPost> = {
-        breed: { $in: postFilters.breed },
-        type: { $in: postFilters.type },
-        age: { $in: postFilters.age },
-        size: { $in: postFilters.size },
-        gender: { $in: postFilters.gender },
+      console.log(postFilters);
+      const baseFilter: FilterQuery<IPost | IDraftPost> = {
+        $or: [{ breed: { $in: postFilters.breed } }, { breed: { $size: 0 } }],
+        type: { $in: [...postFilters.type, null] },
+        age: { $in: [...postFilters.age, null] },
+        size: { $in: [...postFilters.size, null] },
+        gender: { $in: [...postFilters.gender, null] },
         behavioral: { $nin: notAllowedBehavioral },
         getsAlongWithCats: { $in: getsAlongWith["getsAlongWithCats"] },
         getsAlongWithLargeDogs: {

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -140,6 +140,7 @@ export const postRouter = router({
           date: new Date(),
           covered: false,
           usersAppliedTo: [],
+          isDraft: false,
         },
         session
       );
@@ -295,6 +296,7 @@ export const postRouter = router({
           date: existingPost.date,
           covered: existingPost.covered,
           usersAppliedTo: existingPost.usersAppliedTo,
+          isDraft: false,
         });
         return newPost;
       } catch (e) {

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -373,7 +373,6 @@ export const postRouter = router({
         if (!existingPost) {
           throw new Error("Unable to find existing post id.");
         }
-        console.log(input);
         const newPost = await createDraftPost({
           ...input.updateFields,
           date: existingPost.date,

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -347,7 +347,16 @@ export interface IPost {
   usersAppliedTo: string[];
 }
 
-export type IDraftPost = Partial<IPost>;
+export type IDraftPost = Omit<
+  IPost,
+  "type" | "size" | "breed" | "gender" | "age"
+> & {
+  type: FosterType | null;
+  size: Size | null;
+  breed: Breed[] | null;
+  gender: Gender | null;
+  age: Age | null;
+};
 
 export type IFeedPost = Omit<IPost, "usersAppliedTo"> & {
   _id: Types.ObjectId;

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -344,6 +344,7 @@ export interface IPost {
   pending: boolean;
   attachments: string[];
   usersAppliedTo: string[];
+  isDraft: boolean;
 }
 
 export type IFeedPost = Omit<IPost, "usersAppliedTo"> & {

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -347,6 +347,8 @@ export interface IPost {
   usersAppliedTo: string[];
 }
 
+export type IDraftPost = Partial<IPost>;
+
 export type IFeedPost = Omit<IPost, "usersAppliedTo"> & {
   _id: Types.ObjectId;
   userAppliedTo: boolean;
@@ -357,7 +359,10 @@ export type SerializedPost = Omit<IFeedPost, "_id" | "date"> & {
   date: string;
 };
 
-export type IPendingPost = Omit<IPost, "attachments" | "pending"> & {
+export type IPendingPost = Omit<
+  IPost | IDraftPost,
+  "attachments" | "pending"
+> & {
   attachments: AttachmentInfo[];
 };
 

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -341,10 +341,10 @@ export interface IPost {
   getsAlongWithSmallDogs: Trained;
   getsAlongWithCats: Trained;
   covered: boolean;
+  draft: boolean;
   pending: boolean;
   attachments: string[];
   usersAppliedTo: string[];
-  isDraft: boolean;
 }
 
 export type IFeedPost = Omit<IPost, "usersAppliedTo"> & {


### PR DESCRIPTION
## DRAFT PAGES

Added the ability to create and edit drafts on the feed page. The user can also filter by drafts.

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change/migration to run
- Environment config change
- Breaking API change

### Related PRs

- #number_of_pr

### Testing
1. Tested Turning a Post -> Draft
2. Tested turning a Valid Draft -> Post
3. Tested the creation of a draft and then the updating/editing of the draft.
4. Tested Draft deletion.
