### PR TITLE
Nathan/urgent dog pin enhancement

### DIFF
--- a/email-notification/models.ts
+++ b/email-notification/models.ts
@@ -151,6 +151,10 @@ const postSchema = new Schema<IPost | IDraftPost>({
         default: null,
         enum: [...Object.values(FosterType), null],
     },
+    urgent: {
+        type: Boolean,
+        default: false,
+    },
     size: {
         type: String,
         default: null,

--- a/email-notification/types.ts
+++ b/email-notification/types.ts
@@ -142,6 +142,7 @@ export interface IPost {
     name: string;
     description: string;
     type: FosterType;
+    urgent: boolean;
     size: Size;
     breed: Breed[];
     otherBreedDescription?: string;

--- a/web/components/FeedPage/Feed/FeedPostCard.tsx
+++ b/web/components/FeedPage/Feed/FeedPostCard.tsx
@@ -25,7 +25,6 @@ function DefaultDogImage() {
 
 function FeedPostCard(props: { post: IFeedPost }) {
   const { post } = props;
-  console.log(post)
 
   let firstImage;
   const imageExtensions = new Set<string>(["png", "jpeg", "jpg"]);
@@ -110,6 +109,7 @@ function FeedPostCard(props: { post: IFeedPost }) {
             <Text margin="0px" paddingY="0px" fontWeight="bold" fontSize="18px">
               {post.name}
             </Text>
+            <Box display={"flex"} flexDirection={"row"}>
             {fosterTypeLabels[post.type] && (
               <Text
                 margin="0px"
@@ -126,20 +126,24 @@ function FeedPostCard(props: { post: IFeedPost }) {
                 {fosterTypeLabels[post.type]}
               </Text>
             )}
-            <Text
+            {post.urgent !== null && post.urgent === true && (
+              <Text
               margin="0px"
-              backgroundColor="#C6E3F9"
+              backgroundColor="red.200"
               width="fit-content"
               paddingX="16px"
               paddingY="4px"
               borderRadius="20px"
               marginTop="5px"
               marginBottom="10px"
+              marginLeft="10px"
               fontSize="14px"
               fontWeight="semibold"
             >
-              this is urgency status: {post.urgent === false ? "false" : "true"}
+              Urgent
             </Text>
+            )}
+            </Box>
             
             <Text
               fontSize="14px"

--- a/web/components/FeedPage/Feed/FeedPostCard.tsx
+++ b/web/components/FeedPage/Feed/FeedPostCard.tsx
@@ -25,6 +25,7 @@ function DefaultDogImage() {
 
 function FeedPostCard(props: { post: IFeedPost }) {
   const { post } = props;
+  console.log(post)
 
   let firstImage;
   const imageExtensions = new Set<string>(["png", "jpeg", "jpg"]);
@@ -125,6 +126,21 @@ function FeedPostCard(props: { post: IFeedPost }) {
                 {fosterTypeLabels[post.type]}
               </Text>
             )}
+            <Text
+              margin="0px"
+              backgroundColor="#C6E3F9"
+              width="fit-content"
+              paddingX="16px"
+              paddingY="4px"
+              borderRadius="20px"
+              marginTop="5px"
+              marginBottom="10px"
+              fontSize="14px"
+              fontWeight="semibold"
+            >
+              this is urgency status: {post.urgent === false ? "false" : "true"}
+            </Text>
+            
             <Text
               fontSize="14px"
               lineHeight="18px"

--- a/web/components/PetPostModal/EditPostModal.tsx
+++ b/web/components/PetPostModal/EditPostModal.tsx
@@ -94,6 +94,7 @@ const formSchema = z.object({
     })
     .nullable()
     .transform((val, ctx) => nullValidation(val, ctx, "Foster type")),
+  urgent: z.boolean(),
   size: z
     .nativeEnum(Size, { required_error: "Size required." })
     .nullable()
@@ -145,6 +146,7 @@ const EditPostModal: React.FC<{
     name,
     description,
     type,
+    urgent,
     size,
     age,
     draft,
@@ -172,6 +174,7 @@ const EditPostModal: React.FC<{
     gender,
     age,
     type,
+    urgent,
     size,
     breed,
     otherBreedDescription,

--- a/web/components/PostCreationModal/Form/FormSlide.tsx
+++ b/web/components/PostCreationModal/Form/FormSlide.tsx
@@ -291,9 +291,10 @@ export const FormSlide: React.FC<{
             }
           />
         </FormControl>
-        <FormControl className="urgentForm" gridColumn="span 1">
-          <FormLabel>Urgent Foster</FormLabel>
+        <FormControl className="urgentForm" gridColumn="span 1" display={"flex"} marginBottom="10px">
+          <FormLabel marginBottom="0">Urgent Foster</FormLabel>
           <Checkbox
+            size = "lg"
             checked = {formState.urgent}
             onChange = {(e) => {
               dispatchFormState({

--- a/web/components/PostCreationModal/Form/FormSlide.tsx
+++ b/web/components/PostCreationModal/Form/FormSlide.tsx
@@ -295,12 +295,12 @@ export const FormSlide: React.FC<{
           <FormLabel marginBottom="0">Urgent Foster</FormLabel>
           <Checkbox
             size = "lg"
-            checked = {formState.urgent}
+            isChecked = {formState.urgent}
             onChange = {(e) => {
               dispatchFormState({
                 type: "setField",
                 key: "urgent",
-                data: e.currentTarget.checked as boolean,
+                data: e.target.checked as boolean,
               })
             }}
           />

--- a/web/components/PostCreationModal/Form/FormSlide.tsx
+++ b/web/components/PostCreationModal/Form/FormSlide.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Textarea,
   Grid,
+  Checkbox,
 } from "@chakra-ui/react";
 import {
   Age,
@@ -290,6 +291,19 @@ export const FormSlide: React.FC<{
             }
           />
         </FormControl>
+        <FormControl className="urgentForm" gridColumn="span 1">
+          <FormLabel>Urgent Foster</FormLabel>
+          <Checkbox
+            checked = {formState.urgent}
+            onChange = {(e) => {
+              dispatchFormState({
+                type: "setField",
+                key: "urgent",
+                data: e.currentTarget.checked as boolean,
+              })
+            }}
+          />
+        </FormControl>
       </Grid>
       <Box>
         <Grid
@@ -380,11 +394,6 @@ export const FormSlide: React.FC<{
               val={formState.getsAlongWithCats}
               dispatchFormState={dispatchFormState}
             />
-          </Box>
-          <Box></Box>
-          <Box>
-            <Text>Urgent?</Text>
-            <input></input>
           </Box>
         </Grid>
       </Box>

--- a/web/components/PostCreationModal/Form/FormSlide.tsx
+++ b/web/components/PostCreationModal/Form/FormSlide.tsx
@@ -381,6 +381,11 @@ export const FormSlide: React.FC<{
               dispatchFormState={dispatchFormState}
             />
           </Box>
+          <Box></Box>
+          <Box>
+            <Text>Urgent?</Text>
+            <input></input>
+          </Box>
         </Grid>
       </Box>
     </Stack>

--- a/web/components/PostCreationModal/PostCreationModal.tsx
+++ b/web/components/PostCreationModal/PostCreationModal.tsx
@@ -96,6 +96,7 @@ const formSchema = z.object({
     })
     .nullable()
     .transform((val, ctx) => nullValidation(val, ctx, "Foster type")),
+  urgent: z.boolean(),
   size: z
     .nativeEnum(Size, { required_error: "Size required." })
     .nullable()
@@ -159,6 +160,7 @@ const PostCreationModal: React.FC<{
     gender: null,
     age: null,
     type: null,
+    urgent: false,
     size: null,
     breed: [],
     otherBreedDescription: "",
@@ -230,10 +232,12 @@ const PostCreationModal: React.FC<{
       })
     );
     try {
+      console.log(formState)
       const creationInfo = await postCreate.mutateAsync({
         ...(formState as z.output<typeof formSchema>),
         attachments: files,
       });
+      console.log(creationInfo)
       const oid = creationInfo._id;
       const uploadInfo = creationInfo.attachments;
 

--- a/web/db/actions/Post.ts
+++ b/web/db/actions/Post.ts
@@ -402,7 +402,7 @@ async function getFilteredPosts(filter: FilterQuery<IPost>, userUid: string) {
       },
     },
   ])
-    .sort({ date: -1 })
+    .sort({ urgent: -1, date: -1 })
     .exec();
   return posts;
 }

--- a/web/db/actions/__mocks__/Post.ts
+++ b/web/db/actions/__mocks__/Post.ts
@@ -21,6 +21,7 @@ export function createRandomPost(): IPost & { _id: Types.ObjectId } {
     name: faker.person.fullName(),
     description: faker.lorem.sentence(),
     type: faker.helpers.arrayElement(Object.values(FosterType)),
+    urgent: faker.datatype.boolean(),
     size: faker.helpers.arrayElement(Object.values(Size)),
     breed: faker.helpers.uniqueArray(
       Object.values(Breed),
@@ -64,6 +65,7 @@ export function createRandomFeedPost(): IFeedPost {
     name: faker.person.fullName(),
     description: faker.lorem.sentence(),
     type: faker.helpers.arrayElement(Object.values(FosterType)),
+    urgent: faker.datatype.boolean(),
     size: faker.helpers.arrayElement(Object.values(Size)),
     breed: faker.helpers.uniqueArray(
       Object.values(Breed),

--- a/web/db/models/Post.ts
+++ b/web/db/models/Post.ts
@@ -25,6 +25,10 @@ const postSchema = new Schema<IPost | IDraftPost>({
     default: null,
     enum: [...Object.values(FosterType), null],
   },
+  urgent: {
+    type: Boolean,
+    default: false,
+  },
   size: {
     type: String,
     default: null,

--- a/web/pages/post/[postId].tsx
+++ b/web/pages/post/[postId].tsx
@@ -351,7 +351,12 @@ function PostPage({
             {fosterTypeLabels[type] && type !== FosterType.Boarding && (
               <Text>
                 I am a <b>{fosterTypeLabels[type].toLowerCase()}</b> dog.{" "}
-                {fosterTypeDescriptions[type]}
+                {fosterTypeDescriptions[type]} 
+              </Text>
+            )}
+            {urgent && (
+              <Text>
+                Finding a new foster <b>quickly</b> is important for my well-being.
               </Text>
             )}
           </Box>

--- a/web/pages/post/[postId].tsx
+++ b/web/pages/post/[postId].tsx
@@ -148,6 +148,7 @@ function PostPage({
     name,
     description,
     type,
+    urgent,
     size,
     age,
     draft,

--- a/web/server/routers/post.ts
+++ b/web/server/routers/post.ts
@@ -52,6 +52,7 @@ const postSchema = z.object({
   name: z.string(),
   description: z.string(),
   type: z.nativeEnum(FosterType),
+  urgent: z.boolean(),
   size: z.nativeEnum(Size),
   breed: z.array(z.nativeEnum(Breed)),
   otherBreedDescription: z.string().optional(),

--- a/web/utils/types/post.ts
+++ b/web/utils/types/post.ts
@@ -325,6 +325,7 @@ export interface IPost {
   name: string;
   description: string;
   type: FosterType;
+  urgent: boolean;
   size: Size;
   breed: Breed[];
   otherBreedDescription?: string;
@@ -359,6 +360,7 @@ export type IDraftPost = Omit<
   breed: Breed[] | null;
   gender: Gender | null;
   age: Age | null;
+  
 };
 
 export type IFeedPost = Omit<IPost, "usersAppliedTo"> & {


### PR DESCRIPTION
Urgent Dog Post Pin

Issue Number(s): #357 

What does this PR change and why?
Added urgent flag to posts. Urgency of a post can be changed when creating the post or when editing it later with checkbox on formSlide. Urgent posts are pinned to the top of the feed. Relative order is still maintained.

### Checklist

- [ x] Requirements have been implemented
- [ x] Acceptance criteria are met
- [ x] Database schema docs have been updated or are not necessary
- [ x] Code follows design and style guidelines
- [ x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Testing

Created and edited a bunch of posts to ensure urgent tag works.
